### PR TITLE
feat: Pack Talos decision metrics into structure. Add binary to print metrics using kafka message as source.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1928,6 +1928,7 @@ dependencies = [
  "futures-util",
  "log",
  "logger",
+ "metrics",
  "mockall",
  "rdkafka",
  "refinery",

--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,11 @@ dev.cohort_banking:
 	$(call pp,run cohort_banking...)
 	cargo run --example cohort_banking --release -- $(args)
 
+## dev.histogram_decision_timeline_from_kafka: 🧪 Reads all decisions from kafka and prints processing timeline as csv
+dev.histogram_decision_timeline_from_kafka:
+	$(call pp,histogram_decision_timeline_from_kafka...)
+	cargo run --bin histogram_decision_timeline_from_kafka --release -- $(args)
+
 ## dev.run_replicator: 🧪 Runs replicator
 dev.run_replicator:
 	$(call pp,run replicator...)

--- a/examples/cohort_banking/examples/cohort_banking.rs
+++ b/examples/cohort_banking/examples/cohort_banking.rs
@@ -3,7 +3,7 @@ use std::{env, sync::Arc, time::Duration};
 use async_channel::Receiver;
 use cohort::{
     config_loader::ConfigLoader,
-    metrics::{MinMax, Stats},
+    metrics::Stats,
     model::requests::TransferRequest,
     replicator::pg_replicator_installer::PgReplicatorStatemapInstaller,
     replicator2::{cohort_replicator::CohortReplicator, cohort_suffix::CohortSuffix, service::ReplicatorService2},
@@ -14,7 +14,7 @@ use examples_support::{
     load_generator::{generator::ControlledRateLoadGenerator, models::StopType},
 };
 
-use metrics::model::MicroMetrics;
+use metrics::model::{MicroMetrics, MinMax};
 use rand::Rng;
 use talos_certifier::ports::MessageReciever;
 use talos_certifier_adapters::{KafkaConfig, KafkaConsumer};
@@ -136,7 +136,7 @@ fn start_queue_monitor(
                 remaining_attempts -= 1;
                 log::warn!(
                     "Workers queue is empty and there is no activity signal from replicator. Finishing in: {} seconds...",
-                    remaining_attempts
+                    remaining_attempts * check_frequency.as_secs()
                 );
             } else {
                 remaining_attempts = total_attempts;

--- a/packages/cohort/src/bin/replicator.rs
+++ b/packages/cohort/src/bin/replicator.rs
@@ -2,7 +2,6 @@
 
 use cohort::{
     config_loader::ConfigLoader,
-    metrics::MinMax,
     replicator::{
         core::{Replicator, ReplicatorCandidate},
         pg_replicator_installer::PgReplicatorStatemapInstaller,
@@ -11,7 +10,7 @@ use cohort::{
     state::postgres::{data_access::PostgresApi, database::Database},
 };
 use log::{info, warn};
-use metrics::model::MicroMetrics;
+use metrics::model::{MicroMetrics, MinMax};
 use talos_certifier::ports::MessageReciever;
 use talos_certifier_adapters::{KafkaConfig, KafkaConsumer};
 use talos_suffix::{core::SuffixConfig, Suffix};

--- a/packages/cohort/src/metrics.rs
+++ b/packages/cohort/src/metrics.rs
@@ -1,5 +1,7 @@
 use std::{collections::HashMap, time::Duration};
 
+use metrics::model::MinMax;
+
 #[derive(Debug, Clone)]
 pub struct Span {
     pub started: i128,
@@ -32,56 +34,6 @@ impl Default for TxExecSpans {
             span3_certify: Span::new(0, 0),
             span4_wait_for_safepoint: Span::new(0, 0),
             span5_install: Span::new(0, 0),
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct MinMax {
-    pub sum: i128,
-    pub min: i128,
-    pub max: i128,
-    pub count: i128,
-}
-
-impl MinMax {
-    pub fn merge(&mut self, value: MinMax) {
-        if self.min > value.min {
-            self.min = value.min;
-        }
-        if self.max < value.max && value.max < i128::MAX {
-            self.max = value.max;
-        }
-        self.sum += value.sum;
-        self.count += value.count;
-    }
-
-    pub fn add(&mut self, value: i128) {
-        if self.min > value {
-            self.min = value;
-        }
-        if self.max < value && value < i128::MAX {
-            self.max = value;
-        }
-        self.count += 1;
-        self.sum += value;
-    }
-
-    pub fn reset(&mut self) {
-        self.sum = 0;
-        self.min = i128::MAX;
-        self.max = 0;
-        self.count = 0;
-    }
-}
-
-impl Default for MinMax {
-    fn default() -> Self {
-        MinMax {
-            min: i128::MAX,
-            max: 0,
-            count: 0,
-            sum: 0,
         }
     }
 }

--- a/packages/cohort/src/replicator/pg_replicator_installer.rs
+++ b/packages/cohort/src/replicator/pg_replicator_installer.rs
@@ -3,9 +3,9 @@ use std::{io::Error, time::Duration};
 
 use async_trait::async_trait;
 use log::debug;
-use metrics::model::MicroMetrics;
+use metrics::model::{MicroMetrics, MinMax};
 
-use crate::{metrics::MinMax, state::postgres::data_access::PostgresApi, tx_batch_executor::BatchExecutor};
+use crate::{state::postgres::data_access::PostgresApi, tx_batch_executor::BatchExecutor};
 
 use super::core::{ReplicatorInstaller, StatemapItem};
 

--- a/packages/cohort/src/replicator2/service.rs
+++ b/packages/cohort/src/replicator2/service.rs
@@ -1,13 +1,10 @@
 use std::{sync::Arc, time::Duration};
 
-use metrics::model::MicroMetrics;
+use metrics::model::{MicroMetrics, MinMax};
 use talos_certifier::{ports::MessageReciever, ChannelMessage};
 use time::OffsetDateTime;
 
-use crate::{
-    metrics::MinMax,
-    replicator::{core::ReplicatorInstaller, pg_replicator_installer::PgReplicatorStatemapInstaller},
-};
+use crate::replicator::{core::ReplicatorInstaller, pg_replicator_installer::PgReplicatorStatemapInstaller};
 
 use super::cohort_replicator::CohortReplicator;
 use super::model::{InstallOutcome, StateMapWithVersion};

--- a/packages/examples_support/src/cohort/queue_workers.rs
+++ b/packages/examples_support/src/cohort/queue_workers.rs
@@ -5,7 +5,7 @@ use cohort::{
     config_loader::ConfigLoader,
     core::{AgentType, Cohort},
     delay_controller::DelayController,
-    metrics::{MinMax, Span, Stats, TxExecSpans},
+    metrics::{Span, Stats, TxExecSpans},
     model::{
         bank_account::as_money,
         requests::TransferRequest,
@@ -14,7 +14,7 @@ use cohort::{
     snapshot_api::SnapshotApi,
     state::postgres::database::Database,
 };
-use metrics::model::MicroMetrics;
+use metrics::model::{MicroMetrics, MinMax};
 use time::OffsetDateTime;
 use tokio::task::JoinHandle;
 

--- a/packages/metrics/src/model.rs
+++ b/packages/metrics/src/model.rs
@@ -84,3 +84,53 @@ impl MicroMetrics {
         )
     }
 }
+
+#[derive(Debug, Clone)]
+pub struct MinMax {
+    pub sum: i128,
+    pub min: i128,
+    pub max: i128,
+    pub count: i128,
+}
+
+impl MinMax {
+    pub fn merge(&mut self, value: MinMax) {
+        if self.min > value.min {
+            self.min = value.min;
+        }
+        if self.max < value.max && value.max < i128::MAX {
+            self.max = value.max;
+        }
+        self.sum += value.sum;
+        self.count += value.count;
+    }
+
+    pub fn add(&mut self, value: i128) {
+        if self.min > value {
+            self.min = value;
+        }
+        if self.max < value && value < i128::MAX {
+            self.max = value;
+        }
+        self.count += 1;
+        self.sum += value;
+    }
+
+    pub fn reset(&mut self) {
+        self.sum = 0;
+        self.min = i128::MAX;
+        self.max = 0;
+        self.count = 0;
+    }
+}
+
+impl Default for MinMax {
+    fn default() -> Self {
+        MinMax {
+            min: i128::MAX,
+            max: 0,
+            count: 0,
+            sum: 0,
+        }
+    }
+}

--- a/packages/talos_agent/src/agent/decision_reader.rs
+++ b/packages/talos_agent/src/agent/decision_reader.rs
@@ -211,8 +211,7 @@ mod tests {
             suffix_start: 0_u64,
             version: 0_u64,
             safepoint: None,
-            can_received_at: None,
-            created_at: None,
+            metrics: None,
         }
     }
 }

--- a/packages/talos_agent/src/messaging/api.rs
+++ b/packages/talos_agent/src/messaging/api.rs
@@ -70,9 +70,20 @@ pub struct DecisionMessage {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub safepoint: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub can_received_at: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub created_at: Option<u64>,
+    pub metrics: Option<TxProcessingTimeline>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct TxProcessingTimeline {
+    pub candidate_published: i128,
+    pub candidate_received: i128,
+    pub candidate_processing_started: i128,
+    pub decision_created_at: i128,
+    pub db_save_started: i128,
+    pub db_save_ended: i128,
+    #[serde(skip_serializing, skip_deserializing)]
+    pub decision_received_at: i128,
 }
 
 /// The response of message publishing action, essentially this is

--- a/packages/talos_certifier/src/model/decision_message.rs
+++ b/packages/talos_certifier/src/model/decision_message.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::certifier::Outcome;
 
-use super::candidate_message::CandidateMessage;
+use super::{candidate_message::CandidateMessage, metrics::TxProcessingTimeline};
 
 // {
 //     "xid": "38c729ec-dc28-4da4-9b0b-d3ec136a30ff",
@@ -88,14 +88,7 @@ pub struct DecisionMessage {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub conflicts: Option<Vec<ConflictMessage>>,
 
-    pub can_published_at: i128,
-    pub can_received_at: i128,
-    pub can_process_start: i128,
-    pub can_process_end: i128,
-    pub created_at: i128,
-    pub db_start: i128,
-    pub db_end: i128,
-    pub received_at: i128,
+    pub metrics: TxProcessingTimeline,
     //TODO:- Add them in next iteration
     // pub time: String,
     // pub certifier: String,
@@ -129,7 +122,7 @@ impl DecisionMessageTrait for DecisionMessage {
     }
 
     fn get_decided_at(&self) -> i128 {
-        self.created_at
+        self.metrics.decision_created_at
     }
 }
 
@@ -162,14 +155,7 @@ impl DecisionMessage {
             safepoint,
             conflicts,
             duplicate_version: None,
-            can_published_at: candidate_message.published_at,
-            can_received_at: candidate_message.received_at,
-            can_process_start: 0, // set later
-            can_process_end: 0,   // set later
-            created_at: 0,
-            db_start: 0,
-            db_end: 0,
-            received_at: 0,
+            metrics: TxProcessingTimeline::default(),
         }
     }
 }

--- a/packages/talos_certifier/src/model/metrics.rs
+++ b/packages/talos_certifier/src/model/metrics.rs
@@ -1,0 +1,14 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct TxProcessingTimeline {
+    pub candidate_published: i128,
+    pub candidate_received: i128,
+    pub candidate_processing_started: i128,
+    pub decision_created_at: i128,
+    pub db_save_started: i128,
+    pub db_save_ended: i128,
+    #[serde(skip_serializing, skip_deserializing)]
+    pub decision_received_at: i128,
+}

--- a/packages/talos_certifier/src/model/mod.rs
+++ b/packages/talos_certifier/src/model/mod.rs
@@ -1,6 +1,7 @@
 mod candidate_message;
 mod decision_message;
 pub mod delivery_order;
+pub mod metrics;
 
 pub use candidate_message::{CandidateMessage, CandidateReadWriteSet};
 pub use decision_message::{ConflictMessage, Decision, DecisionMessage, DecisionMessageTrait};

--- a/packages/talos_certifier/src/services/certifier_service.rs
+++ b/packages/talos_certifier/src/services/certifier_service.rs
@@ -99,10 +99,11 @@ impl CertifierService {
 
         // Create the Decision Message
         let mut dm = DecisionMessage::new(message, conflict_candidate, outcome, suffix_head);
-        dm.can_received_at = message.received_at;
-        dm.can_process_start = can_process_start;
-        dm.can_process_end = OffsetDateTime::now_utc().unix_timestamp_nanos();
-        dm.created_at = OffsetDateTime::now_utc().unix_timestamp_nanos();
+        let now = OffsetDateTime::now_utc().unix_timestamp_nanos();
+        dm.metrics.candidate_published = message.published_at;
+        dm.metrics.candidate_received = message.received_at;
+        dm.metrics.candidate_processing_started = can_process_start;
+        dm.metrics.decision_created_at = now;
         Ok(dm)
     }
 

--- a/packages/talos_certifier/src/services/decision_outbox_service.rs
+++ b/packages/talos_certifier/src/services/decision_outbox_service.rs
@@ -46,7 +46,7 @@ impl DecisionOutboxService {
     ) -> ServiceResult<DecisionMessage> {
         let xid = decision_message.xid.clone();
 
-        let now = OffsetDateTime::now_utc().unix_timestamp_nanos();
+        let started_at = OffsetDateTime::now_utc().unix_timestamp_nanos();
         let mut decision = datastore
             .insert_decision(xid, decision_message.clone())
             .await
@@ -56,7 +56,7 @@ impl DecisionOutboxService {
                 data: insert_error.data,
                 service: "Decision Outbox Service".to_string(),
             })?;
-        let end = OffsetDateTime::now_utc().unix_timestamp_nanos();
+        let finished_at = OffsetDateTime::now_utc().unix_timestamp_nanos();
 
         if decision.version.ne(&decision_message.version) {
             decision = DecisionMessage {
@@ -66,8 +66,8 @@ impl DecisionOutboxService {
             }
         }
 
-        decision.db_start = now;
-        decision.db_end = end;
+        decision.metrics.db_save_started = started_at;
+        decision.metrics.db_save_ended = finished_at;
         Ok(decision)
     }
 

--- a/packages/talos_certifier/src/services/tests/decision_outbox_service.rs
+++ b/packages/talos_certifier/src/services/tests/decision_outbox_service.rs
@@ -6,7 +6,7 @@ use std::{
 
 use crate::{
     errors::{SystemServiceError, SystemServiceErrorKind},
-    model::{Decision, DecisionMessage},
+    model::{metrics::TxProcessingTimeline, Decision, DecisionMessage},
     ports::{
         common::SharedPortTraits,
         errors::{DecisionStoreError, DecisionStoreErrorKind},
@@ -121,14 +121,7 @@ async fn test_candidate_message_create_decision_message() {
                 duplicate_version: None,
                 safepoint: Some(3),
                 conflicts: None,
-                can_published_at: 0,
-                can_received_at: 0,
-                can_process_start: 0,
-                can_process_end: 0,
-                created_at: 0,
-                db_start: 0,
-                db_end: 0,
-                received_at: 0,
+                metrics: TxProcessingTimeline::default(),
             }))
             .await
             .unwrap();
@@ -187,14 +180,7 @@ async fn test_save_and_publish_multiple_decisions() {
                 duplicate_version: None,
                 safepoint: Some(3),
                 conflicts: None,
-                can_published_at: 0,
-                can_received_at: 0,
-                can_process_start: 0,
-                can_process_end: 0,
-                created_at: 0,
-                db_start: 0,
-                db_end: 0,
-                received_at: 0,
+                metrics: TxProcessingTimeline::default(),
             }))
             .await
             .unwrap();
@@ -212,14 +198,7 @@ async fn test_save_and_publish_multiple_decisions() {
                 duplicate_version: None,
                 safepoint: Some(3),
                 conflicts: None,
-                can_published_at: 0,
-                can_received_at: 0,
-                can_process_start: 0,
-                can_process_end: 0,
-                created_at: 0,
-                db_start: 0,
-                db_end: 0,
-                received_at: 0,
+                metrics: TxProcessingTimeline::default(),
             }))
             .await
             .unwrap();
@@ -315,14 +294,7 @@ async fn test_capture_child_thread_dberror() {
                 duplicate_version: None,
                 safepoint: Some(3),
                 conflicts: None,
-                can_published_at: 0,
-                can_received_at: 0,
-                can_process_start: 0,
-                can_process_end: 0,
-                created_at: 0,
-                db_start: 0,
-                db_end: 0,
-                received_at: 0,
+                metrics: TxProcessingTimeline::default(),
             }))
             .await
             .unwrap();
@@ -374,14 +346,7 @@ async fn test_capture_publish_error() {
         duplicate_version: None,
         safepoint: Some(3),
         conflicts: None,
-        can_published_at: 0,
-        can_received_at: 0,
-        can_process_start: 0,
-        can_process_end: 0,
-        created_at: 0,
-        db_start: 0,
-        db_end: 0,
-        received_at: 0,
+        metrics: TxProcessingTimeline::default(),
     };
 
     if let Err(publish_error) = DecisionOutboxService::publish_decision(&Arc::new(Box::new(mock_decision_publisher)), &decision_message).await {
@@ -441,14 +406,7 @@ async fn test_duplicate_version_found_in_db() {
         duplicate_version: None,
         safepoint: Some(3),
         conflicts: None,
-        can_published_at: 0,
-        can_received_at: 0,
-        can_process_start: 0,
-        can_process_end: 0,
-        created_at: 0,
-        db_start: 0,
-        db_end: 0,
-        received_at: 0,
+        metrics: TxProcessingTimeline::default(),
     };
 
     let result_first_decision = DecisionOutboxService::save_decision_to_xdb(&datastore, &decision_message).await;
@@ -465,14 +423,7 @@ async fn test_duplicate_version_found_in_db() {
         duplicate_version: None,
         safepoint: Some(3),
         conflicts: None,
-        can_published_at: 0,
-        can_received_at: 0,
-        can_process_start: 0,
-        can_process_end: 0,
-        created_at: 0,
-        db_start: 0,
-        db_end: 0,
-        received_at: 0,
+        metrics: TxProcessingTimeline::default(),
     };
     let result_duplicate_decision = DecisionOutboxService::save_decision_to_xdb(&datastore, &decision_message_duplicate_same_xid).await;
 

--- a/packages/talos_certifier_adapters/Cargo.toml
+++ b/packages/talos_certifier_adapters/Cargo.toml
@@ -42,9 +42,10 @@ thiserror = "1.0.31"
 mockall = "0.11.0"
 
 # internal crates
-logger = { path = "../logger" }
-talos_certifier = { path = "../talos_certifier" }
-talos_suffix = { path = "../talos_suffix" }
+logger =            { path = "../logger" }
+metrics =           { path = "../metrics" }
+talos_certifier =   { path = "../talos_certifier" }
+talos_suffix =      { path = "../talos_suffix" }
 
 
 [dev-dependencies]

--- a/packages/talos_certifier_adapters/src/bin/histogram_decision_timeline_from_kafka.rs
+++ b/packages/talos_certifier_adapters/src/bin/histogram_decision_timeline_from_kafka.rs
@@ -1,0 +1,236 @@
+use std::{collections::HashMap, time::Duration};
+
+use metrics::model::MinMax;
+use talos_certifier::{model::metrics::TxProcessingTimeline, ports::MessageReciever, ChannelMessage};
+use talos_certifier_adapters::{KafkaConfig, KafkaConsumer};
+use time::OffsetDateTime;
+use tokio::time::timeout;
+
+#[tokio::main]
+async fn main() -> Result<(), String> {
+    env_logger::builder().format_timestamp_millis().init();
+
+    let mut kafka_config = KafkaConfig::from_env();
+    let mut cfg: HashMap<&'static str, &'static str> = HashMap::new();
+    cfg.insert("enable.auto.commit", "false");
+    cfg.insert("auto.offset.reset", "earliest");
+
+    kafka_config.set_overrides(HashMap::new(), cfg);
+    kafka_config.group_id = format!("talos-metric-histogram-timings-{}", uuid::Uuid::new_v4());
+    let mut kafka_consumer = KafkaConsumer::new(&kafka_config);
+    kafka_consumer.subscribe().await.unwrap();
+
+    log::warn!("Aggregating timelines...");
+    // collect min and max times of each span in the decision processing timeline
+    let aggregates = aggregate_timelines(&mut kafka_consumer).await?;
+    let total_decisions = aggregates.1;
+    let progress_frequency = if total_decisions < 100 {
+        10
+    } else {
+        // every 5%%
+        total_decisions / 5
+    };
+
+    kafka_consumer.unsubscribe().await;
+    kafka_config.group_id = format!("talos-metric-histogram-{}", uuid::Uuid::new_v4());
+    let mut kafka_consumer2 = KafkaConsumer::new(&kafka_config);
+
+    kafka_consumer2.subscribe().await.unwrap();
+
+    log::warn!("Computing histograms of {} decisions", total_decisions);
+
+    let mut bukets_start_at = MinMax::default();
+    bukets_start_at.add(aggregates.0.candidate_published.min);
+    bukets_start_at.add(aggregates.0.candidate_received.min);
+    bukets_start_at.add(aggregates.0.candidate_processing_started.min);
+    bukets_start_at.add(aggregates.0.decision_created_at.min);
+    bukets_start_at.add(aggregates.0.db_save_started.min);
+    bukets_start_at.add(aggregates.0.db_save_ended.min);
+
+    let earliest_bucket_start = bukets_start_at.min;
+
+    log::warn!(
+        "Earliest bucket starts at {:?}",
+        OffsetDateTime::from_unix_timestamp_nanos(earliest_bucket_start)
+    );
+
+    let mut hist_candidate_published = Histogram::new(earliest_bucket_start);
+    let mut hist_candidate_received = Histogram::new(earliest_bucket_start);
+    let mut hist_candidate_processing_started = Histogram::new(earliest_bucket_start);
+    let mut hist_decision_created_at = Histogram::new(earliest_bucket_start);
+    let mut hist_db_save_started = Histogram::new(earliest_bucket_start);
+    let mut hist_db_save_ended = Histogram::new(earliest_bucket_start);
+
+    let mut item_number = 0_u64;
+    loop {
+        let rslt_consumed = timeout(Duration::from_secs(10), kafka_consumer2.consume_message()).await;
+        let message = match rslt_consumed {
+            Ok(Ok(Some(message))) => message,
+            Ok(Err(_)) => continue,
+            _ => break,
+        };
+
+        if let ChannelMessage::Decision(_, msg) = message {
+            // log::warn!("Decision {:?}", msg_decision);
+            item_number += 1;
+            if item_number % progress_frequency == 0 {
+                log::warn!("Progress: {} of {}", item_number, total_decisions);
+            }
+            hist_candidate_published.include(&msg.metrics, msg.metrics.candidate_published);
+            hist_candidate_received.include(&msg.metrics, msg.metrics.candidate_received);
+            hist_candidate_processing_started.include(&msg.metrics, msg.metrics.candidate_processing_started);
+            hist_decision_created_at.include(&msg.metrics, msg.metrics.decision_created_at);
+            hist_db_save_started.include(&msg.metrics, msg.metrics.db_save_started);
+            hist_db_save_ended.include(&msg.metrics, msg.metrics.db_save_ended);
+
+            if item_number == total_decisions {
+                break;
+            }
+        }
+    }
+
+    log::warn!("Reading of messages ended");
+    kafka_consumer2.unsubscribe().await;
+
+    let mut bucket_length = MinMax::default();
+    bucket_length.add(hist_candidate_published.buckets.len() as i128);
+    bucket_length.add(hist_candidate_received.buckets.len() as i128);
+    bucket_length.add(hist_candidate_processing_started.buckets.len() as i128);
+    bucket_length.add(hist_decision_created_at.buckets.len() as i128);
+    bucket_length.add(hist_db_save_started.buckets.len() as i128);
+    bucket_length.add(hist_db_save_ended.buckets.len() as i128);
+
+    log::warn!("Histograms are ready, there are: {} 1 second buckets.", bucket_length.max);
+
+    log::warn!("Headers: 'By Publish Time',,,,,,'-','By Receive Time',,,,,,'-','Processing Started',,,,,,'-','By Decision Created',,,,,,'-','By DB Save Started',,,,,,'-','By DB Save Ended',,,,,");
+    for bucket in 1..bucket_length.max {
+        log::warn!(
+            "METRIC (histograms MAX): {},'-',{},'-',{},'-',{},'-',{},'-',{}",
+            hist_candidate_published.to_csv_max(bucket).await,
+            hist_candidate_received.to_csv_max(bucket).await,
+            hist_candidate_processing_started.to_csv_max(bucket).await,
+            hist_decision_created_at.to_csv_max(bucket).await,
+            hist_db_save_started.to_csv_max(bucket).await,
+            hist_db_save_ended.to_csv_max(bucket).await,
+        );
+    }
+    Ok(())
+}
+
+async fn aggregate_timelines(consumer: &mut KafkaConsumer) -> Result<(TimelineAggregates, u64), String> {
+    let mut total = 0_u64;
+    let mut aggregates = TimelineAggregates::default();
+    loop {
+        let rslt_consumed = timeout(Duration::from_secs(3), consumer.consume_message()).await;
+        let message = match rslt_consumed {
+            Ok(Ok(Some(message))) => message,
+            Ok(Err(_)) => continue,
+            _ => break,
+        };
+
+        if let ChannelMessage::Decision(_, msg_decision) = message {
+            total += 1;
+            aggregates.merge(msg_decision.metrics);
+        }
+    }
+
+    Ok((aggregates, total))
+}
+
+#[derive(Default)]
+struct TimelineAggregates {
+    pub candidate_published: MinMax,
+    pub candidate_received: MinMax,
+    pub candidate_processing_started: MinMax,
+    pub decision_created_at: MinMax,
+    pub db_save_started: MinMax,
+    pub db_save_ended: MinMax,
+}
+
+impl TimelineAggregates {
+    fn merge(&mut self, data: TxProcessingTimeline) {
+        self.candidate_published.add(data.candidate_published);
+        self.candidate_received.add(data.candidate_received);
+        self.candidate_processing_started.add(data.candidate_processing_started);
+        self.decision_created_at.add(data.decision_created_at);
+        self.db_save_started.add(data.db_save_started);
+        self.db_save_ended.add(data.db_save_ended);
+    }
+}
+
+#[derive(Clone)]
+struct Spans {
+    pub span1_candidate_kafka_trip: MinMax,
+    pub span2_talos_internal_bus: MinMax,
+    pub span3_deciding: MinMax,
+    pub span4_prepare_for_save: MinMax,
+    pub span5_save_to_db: MinMax,
+}
+
+impl Spans {
+    fn new() -> Self {
+        Self {
+            span1_candidate_kafka_trip: MinMax::default(),
+            span2_talos_internal_bus: MinMax::default(),
+            span3_deciding: MinMax::default(),
+            span4_prepare_for_save: MinMax::default(),
+            span5_save_to_db: MinMax::default(),
+        }
+    }
+
+    fn include(&mut self, times: &TxProcessingTimeline) {
+        self.span1_candidate_kafka_trip.add(times.candidate_received - times.candidate_published);
+        self.span2_talos_internal_bus.add(times.candidate_processing_started - times.candidate_received);
+        self.span3_deciding.add(times.decision_created_at - times.candidate_processing_started);
+        self.span4_prepare_for_save.add(times.db_save_started - times.decision_created_at);
+        self.span5_save_to_db.add(times.db_save_ended - times.db_save_started);
+    }
+}
+
+struct Histogram {
+    pub start_time: i128,
+    pub buckets: Vec<(u64, Spans)>,
+}
+
+impl Histogram {
+    fn new(start_time: i128) -> Self {
+        Histogram {
+            start_time,
+            buckets: Vec::new(),
+        }
+    }
+
+    fn include(&mut self, metrics: &TxProcessingTimeline, value: i128) {
+        let elapsed = Duration::from_nanos((value - self.start_time) as u64);
+        let bucket = elapsed.as_secs_f32().ceil() as usize;
+        while self.buckets.len() < bucket + 1 {
+            self.buckets.push((0, Spans::new()));
+        }
+
+        if let Some((count, spans)) = self.buckets.get_mut(bucket) {
+            spans.include(metrics);
+            self.buckets[bucket].0 = *count + 1;
+        }
+    }
+
+    async fn get(&self, bucket: usize) -> (u64, Spans) {
+        if let Some(data) = self.buckets.get(bucket) {
+            (data.0, data.1.clone())
+        } else {
+            (0, Spans::new())
+        }
+    }
+
+    async fn to_csv_max(&self, bucket: i128) -> String {
+        let (count, spans) = self.get(bucket as usize).await;
+        format!(
+            "{},{},{},{},{},{}",
+            count,
+            spans.span1_candidate_kafka_trip.max,
+            spans.span2_talos_internal_bus.max,
+            spans.span3_deciding.max,
+            spans.span4_prepare_for_save.max,
+            spans.span5_save_to_db.max,
+        )
+    }
+}

--- a/packages/talos_certifier_adapters/src/kafka/config.rs
+++ b/packages/talos_certifier_adapters/src/kafka/config.rs
@@ -2,7 +2,7 @@ use rdkafka::ClientConfig;
 use std::collections::HashMap;
 use talos_certifier::env_var;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct KafkaConfig {
     pub brokers: Vec<String>,
     pub topic: String,

--- a/packages/talos_certifier_adapters/src/kafka/consumer.rs
+++ b/packages/talos_certifier_adapters/src/kafka/consumer.rs
@@ -123,7 +123,7 @@ impl MessageReciever for KafkaConsumer {
                     reason: e.to_string(),
                     data: Some(format!("{:?}", String::from_utf8_lossy(raw_payload))),
                 })?;
-                msg.received_at = OffsetDateTime::now_utc().unix_timestamp_nanos();
+                msg.metrics.decision_received_at = OffsetDateTime::now_utc().unix_timestamp_nanos();
 
                 debug!("Decision received and the offset is {} !!!! ", offset);
 

--- a/packages/talos_certifier_adapters/src/mock_certifier_service.rs
+++ b/packages/talos_certifier_adapters/src/mock_certifier_service.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use talos_certifier::core::{DecisionOutboxChannelMessage, ServiceResult, SystemService};
 use talos_certifier::errors::{SystemServiceError, SystemServiceErrorKind};
+use talos_certifier::model::metrics::TxProcessingTimeline;
 use talos_certifier::model::{Decision, DecisionMessage};
 use talos_certifier::ports::common::SharedPortTraits;
 use talos_certifier::ChannelMessage;
@@ -40,14 +41,7 @@ impl SystemService for MockCertifierService {
                             safepoint: Some(0),
                             conflicts: None,
                             duplicate_version: None,
-                            can_published_at: 0,
-                            can_received_at: 0,
-                            can_process_start: 0,
-                            can_process_end: 0,
-                            created_at: 0,
-                            db_start: 0,
-                            db_end: 0,
-                            received_at: 0,
+                            metrics: TxProcessingTimeline::default(),
                         };
                         self.decision_outbox_tx
                             .send(DecisionOutboxChannelMessage::Decision(decision_message.clone()))


### PR DESCRIPTION
1. As noted in previous PR, introducing metrics structure in Talos DecisionMessage.
2. Use that data to print CSV histogram (new  binary created)