### PR TITLE
feat: replicator 1 generate statemaps batch when decision is received

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ dev.histogram_decision_timeline_from_kafka:
 ## dev.run_replicator: 🧪 Runs replicator
 dev.run_replicator:
 	$(call pp,run replicator...)
-	cargo run --bin replicator
+	cargo run --bin replicator --release
 
 ## lint: 🧹 Checks for lint failures on rust
 lint:

--- a/examples/cohort_banking/examples/cohort_banking.rs
+++ b/examples/cohort_banking/examples/cohort_banking.rs
@@ -5,8 +5,11 @@ use cohort::{
     config_loader::ConfigLoader,
     metrics::Stats,
     model::requests::TransferRequest,
-    replicator::pg_replicator_installer::PgReplicatorStatemapInstaller,
-    replicator2::{cohort_replicator::CohortReplicator, cohort_suffix::CohortSuffix, service::ReplicatorService2},
+    replicator::{
+        core::{Replicator, ReplicatorCandidate},
+        pg_replicator_installer::PgReplicatorStatemapInstaller,
+        services::{replicator_service::replicator_service, statemap_installer_service::installer_service},
+    },
     state::postgres::{data_access::PostgresApi, database::Database},
 };
 use examples_support::{
@@ -18,7 +21,7 @@ use metrics::model::{MicroMetrics, MinMax};
 use rand::Rng;
 use talos_certifier::ports::MessageReciever;
 use talos_certifier_adapters::{KafkaConfig, KafkaConsumer};
-use talos_suffix::core::SuffixConfig;
+use talos_suffix::{core::SuffixConfig, Suffix};
 use tokio::{signal, sync::Mutex, task::JoinHandle, try_join};
 
 type ReplicatorTaskHandle = JoinHandle<Result<(), String>>;
@@ -175,14 +178,6 @@ async fn start_replicator(
     database: Arc<Database>,
     channel_size: usize,
 ) -> (ReplicatorTaskHandle, InstallerTaskHandle, HeartBeatReceiver) {
-    let suffix_config = SuffixConfig {
-        capacity: 100_000,
-        prune_start_threshold: Some(100_000),
-        min_size_after_prune: None,
-    };
-
-    let suffix = CohortSuffix::with_config(suffix_config);
-
     let mut kafka_config = KafkaConfig::from_env();
     kafka_config.group_id = "talos-replicator-dev".to_string();
     let kafka_consumer = KafkaConsumer::new(&kafka_config);
@@ -190,13 +185,9 @@ async fn start_replicator(
     // b. Subscribe to topic.
     kafka_consumer.subscribe().await.unwrap();
 
-    let (tx_heartbeat, rx_heartbeat) = tokio::sync::watch::channel(0_u64);
-    let tx_heartbeat_ref = Arc::new(tx_heartbeat);
-    let tx_heartbeat_ref1 = Arc::clone(&tx_heartbeat_ref);
+    let (_tx_heartbeat, rx_heartbeat) = tokio::sync::watch::channel(0_u64);
     let (tx_install_req, rx_install_req) = tokio::sync::mpsc::channel(channel_size);
     let (tx_install_resp, rx_install_resp) = tokio::sync::mpsc::channel(channel_size);
-
-    let replicator = CohortReplicator::new(kafka_consumer, suffix);
 
     let manual_tx_api = PostgresApi { client: database.get().await };
     let installer = PgReplicatorStatemapInstaller {
@@ -211,8 +202,15 @@ async fn start_replicator(
         m5_commit: MinMax::default(),
     };
 
-    let future_replicator = ReplicatorService2::start_replicator(replicator, tx_install_req, rx_install_resp, replicator_metrics);
-    let future_installer = ReplicatorService2::start_installer(rx_install_req, tx_install_resp, installer, tx_heartbeat_ref1, replicator_metrics);
+    let suffix_config = SuffixConfig {
+        capacity: 10,
+        prune_start_threshold: Some(2000),
+        min_size_after_prune: None,
+    };
+    let talos_suffix: Suffix<ReplicatorCandidate> = Suffix::with_config(suffix_config);
+    let replicator_v1 = Replicator::new(kafka_consumer, talos_suffix);
+    let future_replicator = replicator_service(tx_install_req, rx_install_resp, replicator_v1);
+    let future_installer = installer_service(rx_install_req, tx_install_resp, installer);
 
     let h_replicator = tokio::spawn(future_replicator);
     let h_installer = tokio::spawn(future_installer);

--- a/packages/cohort/src/bin/replicator.rs
+++ b/packages/cohort/src/bin/replicator.rs
@@ -23,7 +23,7 @@ async fn main() {
     // 0. Create required items.
     //  a. Create Kafka consumer
     let mut kafka_config = KafkaConfig::from_env();
-    kafka_config.group_id = "talos-replicator-dev".to_string();
+    kafka_config.group_id = "talos-replicator-dev-1".to_string();
     let kafka_consumer = KafkaConsumer::new(&kafka_config);
 
     // b. Subscribe to topic.

--- a/packages/cohort/src/replicator/core.rs
+++ b/packages/cohort/src/replicator/core.rs
@@ -1,17 +1,24 @@
 use async_trait::async_trait;
-use log::{info, warn};
+use log::warn;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::{collections::HashMap, io::Error, marker::PhantomData};
+use std::{
+    collections::HashMap,
+    io::Error,
+    marker::PhantomData,
+    time::{Duration, Instant},
+};
 use talos_certifier::{
     model::{CandidateMessage, DecisionMessageTrait},
     ports::MessageReciever,
     ChannelMessage,
 };
+use time::OffsetDateTime;
 
-use crate::replicator::utils::{get_filtered_batch, get_statemap_from_suffix_items};
-
-use super::suffix::{ReplicatorSuffixItemTrait, ReplicatorSuffixTrait};
+use super::{
+    suffix::{ReplicatorSuffixItemTrait, ReplicatorSuffixTrait},
+    utils::{get_filtered_batch, get_statemap_from_suffix_items},
+};
 
 #[derive(Debug)]
 pub enum ReplicatorChannel {
@@ -99,6 +106,7 @@ where
 {
     pub receiver: M,
     pub suffix: S,
+    pub last_installing: u64,
     _phantom: PhantomData<T>,
 }
 
@@ -112,6 +120,7 @@ where
         Replicator {
             receiver,
             suffix,
+            last_installing: 0,
             _phantom: PhantomData,
         }
     }
@@ -141,21 +150,42 @@ where
         }
     }
 
-    pub(crate) fn generate_statemap_batch(&self) -> (Option<Vec<StatemapItem>>, Option<u64>) {
-        let Some(batch) = self.suffix.get_message_batch(Some(1)) else {
-            return (None, None);
-        };
+    pub(crate) fn generate_statemap_batch(&mut self) -> Vec<(u64, Vec<StatemapItem>)> {
+        let instance = OffsetDateTime::now_utc().unix_timestamp_nanos();
+        let msg_batch_instance = Instant::now();
+        // get batch of items from suffix to install.
+        let items_option = self.suffix.get_message_batch_from_version(self.last_installing, None);
+        let msg_batch_instance_elapsed = msg_batch_instance.elapsed();
 
-        let version = batch.last().unwrap().item_ver;
+        let mut statemaps_batch = vec![];
 
-        // Filtering out messages that are not applicable.
-        let filtered_message_batch = get_filtered_batch(batch.iter().copied());
+        #[allow(unused_assignments)]
+        let mut msg_statemap_create_elapsed = Duration::from_nanos(0);
 
-        // Create the statemap batch
-        let statemap_batch = get_statemap_from_suffix_items(filtered_message_batch);
+        if let Some(items) = items_option {
+            let msg_batch_instance_filter = Instant::now();
+            let filtered_message_batch = get_filtered_batch(items.iter().copied());
+            let msg_batch_instance_filter_elapsed = msg_batch_instance_filter.elapsed();
 
-        info!("Statemap_Batch={statemap_batch:#?} ");
+            let msg_statemap_create = Instant::now();
+            // generate the statemap from each item in batch.
+            statemaps_batch = get_statemap_from_suffix_items(filtered_message_batch);
 
-        (Some(statemap_batch), Some(version))
+            msg_statemap_create_elapsed = msg_statemap_create.elapsed();
+
+            let elapsed = OffsetDateTime::now_utc().unix_timestamp_nanos() - instance;
+
+            if let Some(last_item) = items.last() {
+                self.last_installing = last_item.item_ver;
+            }
+
+            // TODO: Remove TEMP_CODE and replace with proper metrics from feature/cohort-db-mock
+            if !items.is_empty() {
+                let first_version = items.first().unwrap().item_ver;
+                let last_version = items.last().unwrap().item_ver;
+                warn!("[CREATE_STATEMAP] Processed total of count={} from_version={first_version:?} to_version={last_version:?} with batch_create_time={:?}, filter_time={msg_batch_instance_filter_elapsed:?}  statemap_create_time={msg_statemap_create_elapsed:?} and total_time={elapsed:?} {}", items.len(), msg_batch_instance_elapsed, elapsed);
+            };
+        }
+        statemaps_batch
     }
 }

--- a/packages/cohort/src/replicator/core.rs
+++ b/packages/cohort/src/replicator/core.rs
@@ -2,18 +2,12 @@ use async_trait::async_trait;
 use log::warn;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::{
-    collections::HashMap,
-    io::Error,
-    marker::PhantomData,
-    time::{Duration, Instant},
-};
+use std::{collections::HashMap, io::Error, marker::PhantomData};
 use talos_certifier::{
     model::{CandidateMessage, DecisionMessageTrait},
     ports::MessageReciever,
     ChannelMessage,
 };
-use time::OffsetDateTime;
 
 use super::{
     suffix::{ReplicatorSuffixItemTrait, ReplicatorSuffixTrait},
@@ -151,40 +145,40 @@ where
     }
 
     pub(crate) fn generate_statemap_batch(&mut self) -> Vec<(u64, Vec<StatemapItem>)> {
-        let instance = OffsetDateTime::now_utc().unix_timestamp_nanos();
-        let msg_batch_instance = Instant::now();
+        // let instance = OffsetDateTime::now_utc().unix_timestamp_nanos();
+        // let msg_batch_instance = Instant::now();
         // get batch of items from suffix to install.
         let items_option = self.suffix.get_message_batch_from_version(self.last_installing, None);
-        let msg_batch_instance_elapsed = msg_batch_instance.elapsed();
+        // let msg_batch_instance_elapsed = msg_batch_instance.elapsed();
 
         let mut statemaps_batch = vec![];
 
-        #[allow(unused_assignments)]
-        let mut msg_statemap_create_elapsed = Duration::from_nanos(0);
+        // #[allow(unused_assignments)]
+        // let mut msg_statemap_create_elapsed = Duration::from_nanos(0);
 
         if let Some(items) = items_option {
-            let msg_batch_instance_filter = Instant::now();
+            // let msg_batch_instance_filter = Instant::now();
             let filtered_message_batch = get_filtered_batch(items.iter().copied());
-            let msg_batch_instance_filter_elapsed = msg_batch_instance_filter.elapsed();
+            // let msg_batch_instance_filter_elapsed = msg_batch_instance_filter.elapsed();
 
-            let msg_statemap_create = Instant::now();
+            // let msg_statemap_create = Instant::now();
             // generate the statemap from each item in batch.
             statemaps_batch = get_statemap_from_suffix_items(filtered_message_batch);
 
-            msg_statemap_create_elapsed = msg_statemap_create.elapsed();
+            // msg_statemap_create_elapsed = msg_statemap_create.elapsed();
 
-            let elapsed = OffsetDateTime::now_utc().unix_timestamp_nanos() - instance;
+            // let elapsed = OffsetDateTime::now_utc().unix_timestamp_nanos() - instance;
 
             if let Some(last_item) = items.last() {
                 self.last_installing = last_item.item_ver;
             }
 
             // TODO: Remove TEMP_CODE and replace with proper metrics from feature/cohort-db-mock
-            if !items.is_empty() {
-                let first_version = items.first().unwrap().item_ver;
-                let last_version = items.last().unwrap().item_ver;
-                warn!("[CREATE_STATEMAP] Processed total of count={} from_version={first_version:?} to_version={last_version:?} with batch_create_time={:?}, filter_time={msg_batch_instance_filter_elapsed:?}  statemap_create_time={msg_statemap_create_elapsed:?} and total_time={elapsed:?} {}", items.len(), msg_batch_instance_elapsed, elapsed);
-            };
+            // if !items.is_empty() {
+            //     let first_version = items.first().unwrap().item_ver;
+            //     let last_version = items.last().unwrap().item_ver;
+            //     debug!("[CREATE_STATEMAP] Processed total of count={} from_version={first_version:?} to_version={last_version:?} with batch_create_time={:?}, filter_time={msg_batch_instance_filter_elapsed:?}  statemap_create_time={msg_statemap_create_elapsed:?} and total_time={elapsed:?} {}", items.len(), msg_batch_instance_elapsed, elapsed);
+            // };
         }
         statemaps_batch
     }

--- a/packages/cohort/src/replicator/services/replicator_service.rs
+++ b/packages/cohort/src/replicator/services/replicator_service.rs
@@ -1,5 +1,5 @@
 // $coverage:ignore-start
-use std::{fmt::Debug, time::Duration};
+use std::fmt::Debug;
 
 use crate::replicator::{
     core::{Replicator, ReplicatorCandidate, ReplicatorChannel, StatemapItem},
@@ -20,7 +20,6 @@ where
     M: MessageReciever<Message = ChannelMessage> + Send + Sync,
 {
     info!("Starting Replicator Service.... ");
-    let mut interval = tokio::time::interval(Duration::from_millis(1_000));
 
     loop {
         tokio::select! {
@@ -39,33 +38,20 @@ where
                     ChannelMessage::Decision(decision_version, decision_message) => {
                         replicator.process_decision_message(decision_version, decision_message).await;
 
+
+                        // Get a batch of remaining versions with their statemaps to install.
+                        let statemaps_batch = replicator.generate_statemap_batch();
+
+                        if !statemaps_batch.is_empty() {
+                            for (vers, statemaps_to_install) in statemaps_batch {
+                                // send for install.
+                                statemaps_tx.send((statemaps_to_install, Some(vers))).await.unwrap();
+
+                            };
+                        }
+
+
                     },
-                }
-            }
-        }
-        // 3. At set interval send the batch to be installed.
-        //  3.1 Derive the new snapshot.
-        //  3.2 Create batch of valid statemap instructions.
-        //      (a) Select only the messages that have safepoint (i.e candidate messages with committed decisions).
-        //      (b) Select only the messages that have statemap.
-        //      (c) Send it to the state manager to do the updates.
-        _ = interval.tick() => {
-
-            if let (Some(statemap_batch), version_option) = replicator.generate_statemap_batch() {
-                if version_option.is_some() {
-
-                    info!("Statemap batch in replicator_service is ={statemap_batch:?}");
-
-                    debug!("Getting ready to send the statemap for installation statemap_batch={statemap_batch:?} with version={version_option:?}");
-
-                    let Err(error) = statemaps_tx.send((statemap_batch, version_option)).await else {
-                        debug!("Send successfully over statemap channel");
-                        continue;
-                    };
-
-                    return Err(error.to_string());
-
-
                 }
             }
         }
@@ -74,10 +60,12 @@ where
                 match result {
                     // 4. Remove the versions if installations are complete.
                     ReplicatorChannel::InstallationSuccess(vers) => {
+
                         let version = vers.last().unwrap().to_owned();
                         debug!("Installated successfully till version={version:?}");
                         // Mark the suffix item as installed.
                         replicator.suffix.set_item_installed(version);
+
                         // if all prior items are installed, then update the prune vers
                         replicator.suffix.update_prune_index(version);
 
@@ -97,81 +85,5 @@ where
         }
     }
 }
-
-// pub async fn run_talos_replicator<S, M, T>(replicator: &mut Replicator<ReplicatorCandidate, S, M>, statemap_installer: &mut T)
-// where
-//     S: ReplicatorSuffixTrait<ReplicatorCandidate> + Debug,
-//     M: MessageReciever<Message = ChannelMessage> + Send + Sync,
-//     T: ReplicatorInstaller,
-// {
-//     info!("Going to consume the message.... ");
-//     let mut interval = tokio::time::interval(Duration::from_millis(200));
-
-//     loop {
-//         tokio::select! {
-//             // 1. Consume message.
-//             res = replicator.receiver.consume_message() => {
-//                 if let Ok(Some(msg)) = res {
-
-//                     // 2. Add/update to suffix.
-//                     match msg {
-//                         // 2.1 For CM - Install messages on the version
-//                         ChannelMessage::Candidate( message) => {
-//                             let version = message.version;
-//                             replicator.process_consumer_message(version, message.into()).await;
-//                         },
-//                         // 2.2 For DM - Update the decision with outcome + safepoint.
-//                         ChannelMessage::Decision(decision_version, decision_message) => {
-//                             replicator.process_decision_message(decision_version, decision_message).await;
-
-//                         },
-//                     }
-//                 }
-//             }
-//             // 3. At set interval send the batch to be installed.
-//             //  3.1 Derive the new snapshot.
-//             //  3.2 Create batch of valid statemap instructions.
-//             //      (a) Select only the messages that have safepoint (i.e candidate messages with committed decisions).
-//             //      (b) Select only the messages that have statemap.
-//             //      (c) Send it to the state manager to do the updates.
-//             _ = interval.tick() => {
-
-//                 if let (Some(statemap_batch), version_option) = replicator.generate_statemap_batch() {
-//                     if version_option.is_some() {
-
-//                         info!("Statemap batch in replicator_service is ={statemap_batch:?}");
-//                         // let version = statemap_batch.iter().last().unwrap().version;
-//                         // Call fn to install statemaps in batch amd update the snapshot
-//                         let version = version_option.unwrap();
-
-//                         let result = statemap_installer.install(statemap_batch, version_option).await;
-
-//                         info!("Installation result ={result:?}");
-
-//                         // 4. Remove the versions if installations are complete.
-//                         if let Ok(res) = result {
-//                             if res {
-
-//                                 // Mark the suffix item as installed.
-//                                 replicator.suffix.set_item_installed(version);
-//                                 // if all prior items are installed, then update the prune vers
-//                                 replicator.suffix.update_prune_index(version);
-
-//                                 // Prune suffix and update suffix head.
-//                                 if replicator.suffix.get_suffix_meta().prune_index >= replicator.suffix.get_suffix_meta().prune_start_threshold {
-//                                     replicator.suffix.prune_till_version(version).unwrap();
-//                                 }
-
-//                                 // commit the offset
-//                                 replicator.receiver.commit(version).await.unwrap();
-//                             }
-
-//                         }
-//                     }
-//                 }
-//             }
-//         }
-//     }
-// }
 
 // $coverage:ignore-end

--- a/packages/cohort/src/replicator/services/replicator_service.rs
+++ b/packages/cohort/src/replicator/services/replicator_service.rs
@@ -1,12 +1,12 @@
 // $coverage:ignore-start
-use std::{fmt::Debug, time::Instant};
+use std::fmt::Debug;
 
 use crate::replicator::{
     core::{Replicator, ReplicatorCandidate, ReplicatorChannel, StatemapItem},
     suffix::ReplicatorSuffixTrait,
 };
 
-use log::{debug, info, warn};
+use log::{debug, info};
 use talos_certifier::{ports::MessageReciever, ChannelMessage};
 use tokio::sync::mpsc;
 
@@ -43,31 +43,8 @@ where
                         let statemaps_batch = replicator.generate_statemap_batch();
 
                         if !statemaps_batch.is_empty() {
-                            let statemaps_tx_clone = statemaps_tx.clone();
-                            tokio::spawn(async move {
-                                let instance = Instant::now();
-                                let statemaps_batch_len = statemaps_batch.len();
-                                let first_item_version = statemaps_batch.first().unwrap().0;
-                                let last_item_version = statemaps_batch.last().unwrap().0;
-                                statemaps_tx_clone.send(statemaps_batch).await.unwrap();
-                                // for (vers, statemaps_to_install) in statemaps_batch.clone() {
-                                //     // send for install.
-                                //     if let Err(e) = statemaps_tx_clone.send((statemaps_to_install, Some(vers))).await {
-                                //         return Err(e)
-                                //     };
-
-                                // };
-                                let elapsed = instance.elapsed();
-                                warn!("Total items send over channel count={} first_version={first_item_version} --> last_version={last_item_version} and time taken to send={elapsed:?}", statemaps_batch_len);
-
-                                // Ok(())
-                            });
-                            // handle.await.unwrap();
-                            // if let Err(e) = handle.await.unwrap() {
-                            //     error!("Error sending statemaps over the channel with reason={e:?}");
-                            // }
+                            statemaps_tx.send(statemaps_batch).await.unwrap();
                         }
-
 
                     },
                 }

--- a/packages/cohort/src/replicator/services/statemap_installer_service.rs
+++ b/packages/cohort/src/replicator/services/statemap_installer_service.rs
@@ -6,7 +6,7 @@ use log::{debug, info};
 use tokio::sync::mpsc;
 
 pub async fn installer_service<T>(
-    mut statemaps_rx: mpsc::Receiver<(Vec<StatemapItem>, Option<u64>)>,
+    mut statemaps_rx: mpsc::Receiver<Vec<(u64, Vec<StatemapItem>)>>,
     replicator_tx: mpsc::Sender<ReplicatorChannel>,
     mut statemap_installer: T,
 ) -> Result<(), String>
@@ -16,19 +16,18 @@ where
     info!("Starting Installer Service.... ");
 
     loop {
-        if let Some((statemap_batch, version_option)) = statemaps_rx.recv().await {
-            debug!("[Statemap Installer Service] Received statemap batch ={statemap_batch:?} and version_option={version_option:?}");
-            match statemap_installer.install(statemap_batch, version_option).await {
-                Ok(true) => {
-                    replicator_tx
-                        .send(ReplicatorChannel::InstallationSuccess(vec![version_option.unwrap()]))
-                        .await
-                        .unwrap();
+        if let Some(batch) = statemaps_rx.recv().await {
+            for (ver, statemap_batch) in batch {
+                debug!("[Statemap Installer Service] Received statemap batch ={statemap_batch:?} and version={ver:?}");
+                match statemap_installer.install(statemap_batch, Some(ver)).await {
+                    Ok(true) => {
+                        replicator_tx.send(ReplicatorChannel::InstallationSuccess(vec![ver])).await.unwrap();
+                    }
+                    Ok(false) => {
+                        // Do nothing if result is false.
+                    }
+                    Err(err) => return Err(err.to_string()),
                 }
-                Ok(false) => {
-                    // Do nothing if result is false.
-                }
-                Err(err) => return Err(err.to_string()),
             }
         }
     }

--- a/packages/cohort/src/replicator/tests/suffix.rs
+++ b/packages/cohort/src/replicator/tests/suffix.rs
@@ -81,7 +81,7 @@ fn test_replicator_suffix() {
     suffix.insert(8, TestReplicatorSuffixItem::default()).unwrap();
 
     // Message batch is empty as the decision is not added.
-    assert_eq!(suffix.get_message_batch(Some(5)), None);
+    assert_eq!(suffix.get_message_batch_from_version(5, Some(5)), None);
 
     // Nothing happens for version 50 updates as the item doesn't exist.
     suffix.set_safepoint(50, Some(2));
@@ -90,37 +90,39 @@ fn test_replicator_suffix() {
     //add safepoint and decision for version 3
     suffix.set_safepoint(3, Some(2));
     suffix.set_decision_outcome(3, Some(CandidateDecisionOutcome::Committed));
+    suffix.update_decision(3, 10).unwrap();
 
     let item_at_version3 = suffix.get(3).unwrap().unwrap();
     assert_eq!(item_at_version3.item.safepoint.unwrap(), 2);
     assert_eq!(item_at_version3.item.decision.unwrap(), CandidateDecisionOutcome::Committed);
-    suffix.update_decision(3, 10).unwrap();
+    assert!(!item_at_version3.item.is_installed);
     // Message batch will be one as only version 3's decision is recorded..
-    assert_eq!(suffix.get_message_batch(Some(5)).unwrap().len(), 1);
+    assert_eq!(suffix.get_message_batch_from_version(0, None).unwrap().len(), 1);
 
     suffix.update_decision(4, 12).unwrap();
     // Message batch will still be 1 as there was no version 1 inserted.
     // So the decision will be discarded
-    assert_eq!(suffix.get_message_batch(Some(4)).unwrap().len(), 1);
+    assert_eq!(suffix.get_message_batch_from_version(0, Some(4)).unwrap().len(), 1);
 
     suffix.update_decision(5, 19).unwrap();
     // Message batch will be 2 as safepoint is not set a decision is made, therefore version 3 and 4 are picked.
     // version 3 is considered as commited as the safepoint and decision_outcome is set.
     // version 4 is considered as aborted at this point as safepoint is not set.
-    assert_eq!(suffix.get_message_batch(Some(10)).unwrap().len(), 2);
+    assert_eq!(suffix.get_message_batch_from_version(0, Some(10)).unwrap().len(), 2);
+    assert_eq!(suffix.get_message_batch_from_version(3, Some(10)).unwrap().len(), 1);
 
     //add safepoint and decision for version 8
     suffix.update_decision(8, 19).unwrap();
     suffix.set_safepoint(8, Some(2));
     suffix.set_decision_outcome(8, Some(CandidateDecisionOutcome::Committed));
     // Message batch will be 3, as version 3,5, and 8 are not installed.
-    assert_eq!(suffix.get_message_batch(Some(10)).unwrap().len(), 3);
+    assert_eq!(suffix.get_message_batch_from_version(0, Some(10)).unwrap().len(), 3);
 
     //add safepoint and decision for version 5
     suffix.set_safepoint(5, Some(2));
     suffix.set_decision_outcome(5, Some(CandidateDecisionOutcome::Committed));
     // Message batch will be 3  as version 3, 4 and 5 has Some safepoint value
-    assert_eq!(suffix.get_message_batch(Some(10)).unwrap().len(), 3);
+    assert_eq!(suffix.get_message_batch_from_version(0, Some(10)).unwrap().len(), 3);
 }
 
 #[test]
@@ -143,10 +145,10 @@ fn test_replicator_suffix_installed() {
     suffix.set_decision_outcome(3, Some(CandidateDecisionOutcome::Committed));
 
     // Batch returns one item as only version 3 is decided, others haven't got the decisions yet.
-    assert_eq!(suffix.get_message_batch(Some(1)).unwrap().len(), 1);
+    assert_eq!(suffix.get_message_batch_from_version(0, Some(1)).unwrap().len(), 1);
     suffix.set_item_installed(3);
     // Batch returns 0 items as version 3 is already installed, others haven't got the decisions yet.
-    assert!(suffix.get_message_batch(Some(1)).is_none());
+    assert!(suffix.get_message_batch_from_version(0, Some(1)).is_none());
 
     let suffix_item_3 = suffix.get(3).unwrap().unwrap();
     // confirm version 3 is marked as installed.
@@ -157,14 +159,14 @@ fn test_replicator_suffix_installed() {
     suffix.set_safepoint(9, Some(2));
     suffix.set_decision_outcome(9, Some(CandidateDecisionOutcome::Committed));
     // Batch returns 0, because there is a version in between which is not decided.
-    assert!(suffix.get_message_batch(Some(1)).is_none());
+    assert!(suffix.get_message_batch_from_version(0, Some(1)).is_none());
 
     // update decision for version 6
     suffix.update_suffix_item_decision(6, 23).unwrap();
     suffix.set_safepoint(6, None);
     suffix.set_decision_outcome(6, Some(CandidateDecisionOutcome::Aborted));
     // Batch returns 2 items (version 6 &  9).
-    let batch = suffix.get_message_batch(None).unwrap();
+    let batch = suffix.get_message_batch_from_version(0, None).unwrap();
     assert_eq!(batch.len(), 2);
 
     // Confirm the batch returned the correct item.
@@ -173,7 +175,7 @@ fn test_replicator_suffix_installed() {
     // Mark version 9 as installed.
     suffix.set_item_installed(9);
     // Although version 9 is installed, version 6 is not, therefore it is picked up here.
-    assert_eq!(suffix.get_message_batch(Some(1)).unwrap().len(), 1);
+    assert_eq!(suffix.get_message_batch_from_version(3, Some(1)).unwrap().len(), 1);
 
     assert_eq!(suffix.get_suffix_meta().head, 3);
 }

--- a/packages/cohort/src/replicator/tests/utils.rs
+++ b/packages/cohort/src/replicator/tests/utils.rs
@@ -77,11 +77,11 @@ fn test_get_all_statemap_from_suffix_items() {
     let result = get_filtered_batch(suffix_item.into_iter());
 
     let state_map_batch = get_statemap_from_suffix_items(result);
-    assert_eq!(state_map_batch.len(), 10);
-    assert_eq!(state_map_batch[0].version, 10);
-    assert_eq!(state_map_batch[2].version, 10);
-    assert_eq!(state_map_batch[3].version, 12);
-    assert_eq!(state_map_batch.last().unwrap().version, 16);
+    assert_eq!(state_map_batch[0].1.len(), 3); // three items in statemap for version 10
+    assert_eq!(state_map_batch[0].0, 10);
+    assert_eq!(state_map_batch[2].0, 13);
+    assert_eq!(state_map_batch[3].0, 16);
+    assert_eq!(state_map_batch.last().unwrap().0, 16);
 }
 
 #[test]
@@ -96,5 +96,7 @@ fn test_get_statemap_from_suffix_items_no_statemaps() {
     // let result = get_filtered_batch(suffix_item.into_iter());
 
     let state_map_batch = get_statemap_from_suffix_items(suffix_item.into_iter());
-    assert!(state_map_batch.is_empty());
+    assert_eq!(state_map_batch.len(), 2);
+    assert!(state_map_batch[0].1.is_empty());
+    assert!(state_map_batch[1].1.is_empty());
 }


### PR DESCRIPTION
Improved the algorithm and the frequency at which the statemaps are send to installer.

This doesn't have metrics, but will be added in subsequent PRs. 
