### PR TITLE
feat: Add banking db migrations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,11 +189,11 @@ dependencies = [
  "deadpool-postgres",
  "env_logger",
  "log",
- "refinery",
  "rust_decimal",
  "serde",
  "serde_json",
  "strum 0.25.0",
+ "talos_common_utils",
  "tokio-postgres",
 ]
 
@@ -500,6 +500,7 @@ dependencies = [
  "opentelemetry_api",
  "opentelemetry_sdk",
  "rand",
+ "refinery",
  "rust_decimal",
  "serde",
  "serde_json",
@@ -507,6 +508,7 @@ dependencies = [
  "talos_agent",
  "talos_certifier",
  "talos_cohort_replicator",
+ "talos_common_utils",
  "talos_suffix",
  "tokio",
  "tokio-postgres",

--- a/Makefile
+++ b/Makefile
@@ -48,16 +48,6 @@ pg.migrate:
 	$(call pp,running migrations on database...)
 	cargo run --example pg_migrations
 
-## pg.create_cohort: 🥁 Create database for cohort and applies DB sql
-pg.create_cohort:
-	$(call pp,creating database for cohort...)
-	cargo run --package cohort --bin run_db_migrations create-db migrate-db
-
-## pg.migrate_cohort: 🥁 Run sql on database for cohort
-pg.migrate_cohort:
-	$(call pp,running migrations on database for cohort...)
-	cargo run --package cohort --bin run_db_migrations
-
 # TEST / DEPLOY ###################################################################################
 
 ## install: 🧹 Installs dependencies
@@ -75,11 +65,6 @@ build:
 	$(call pp,build rust...)
 	cargo build
 
-## dev.run-agent-client: 🧪 Runs agent
-dev.run-agent-client:
-	$(call pp,run-agent-client app...)
-	cargo run --example agent_client --release -- $(args)
-
 ## init.samply: 🧪 Installs Samply profiler
 init.samply:
 	cargo install samply
@@ -88,24 +73,29 @@ init.samply:
 init.flamegraph:
 	cargo install flamegraph
 
-## dev.agent-run-profiler-samply: 🧪 Runs agent with Samply profiler
-dev.agent-run-profiler-samply:
+## agent.run-client: 🧪 Executes load test through Talos Agent
+agent.run-client:
+	$(call pp,runing Talos Agent example...)
+	cargo run --example agent_client --release -- $(args)
+
+## agent.run-profiler-samply: 🧪 Runs agent with Samply profiler
+agent.run-profiler-samply:
 	$(call pp,run-agent app...)
 	cargo build --example agent_client
 	samply record -o logs/samply-agent.json -s cargo run --example agent_client
 	samply load logs/samply-agent.json
 
-## dev.agent-run-profiler-flamegraph: 🧪 Runs agent with Flamegraph profiler
+## agent.run-profiler-flamegraph: 🧪 Runs agent with Flamegraph profiler
 # Add CARGO_PROFILE_RELEASE_DEBUG=true to .env
-dev.agent-run-profiler-flamegraph:
+agent.run-profiler-flamegraph:
 	$(call pp,run-agent app...)
 	cargo build --example agent_client
 	rm logs/flamegraph-agent.svg | true
 	sudo cargo flamegraph -o logs/flamegraph-agent.svg --open --example agent_client
 
-## dev.agent-run-profiler-xcode-cpu: 🧪 Runs agent with XCode profiler for Time (CPU) Profiler (OSX only)
+## agent.run-profiler-xcode-cpu: 🧪 Runs agent with XCode profiler for Time (CPU) Profiler (OSX only)
 # Make sure XCode is installed
-dev.agent-run-profiler-xcode-cpu:
+agent.run-profiler-xcode-cpu:
 	$(call pp,run-agent app...)
 	cargo build --release --example agent_client
 	scripts/sign-binary-for-profiling.sh target/release/examples/agent_client
@@ -115,9 +105,9 @@ dev.agent-run-profiler-xcode-cpu:
 	xctrace record --template 'Time Profiler' --output logs/agent-time.trace --attach `pgrep agent_client`
 	open logs/agent-cpu.trace
 
-## dev.agent-run-profiler-xcode-mem: 🧪 Runs agent with XCode profiler for Allocations (OSX only)
+## agent.run-profiler-xcode-mem: 🧪 Runs agent with XCode profiler for Allocations (OSX only)
 # Make sure XCode is installed
-dev.agent-run-profiler-xcode-mem:
+agent.run-profiler-xcode-mem:
 	$(call pp,run-agent app...)
 	cargo build --release --example agent_client
 	scripts/sign-binary-for-profiling.sh target/release/examples/agent_client
@@ -127,66 +117,67 @@ dev.agent-run-profiler-xcode-mem:
 	xctrace record --template 'Allocations' --output logs/agent-allocations.trace --attach `pgrep agent_client`
 	open logs/agent-allocations.trace
 
-## dev.run: 🧪 Runs rust app in watch mode
+## dev.run: 🧪 Runs Talos Certifier app in watch mode
 dev.run:
 	$(call pp,run app...)
 	cargo  watch -q -c -x 'run --example certifier_kafka_pg'
-## run: 🧪 Runs rust app
+
+## run: 🧪 Runs Talos Certifier app
 run:
-	$(call pp,run app...)
+	$(call pp,running Talos Certifier...)
 	cargo run --example certifier_kafka_pg
 
-## run.release: 🧪 Runs rust app in release mode
+## run.release: 🧪 Runs Talos Certifier app in release mode
 run.release:
-	$(call pp,run app...)
+	$(call pp,running Talos Certifier...)
 	cargo run -r --example certifier_kafka_pg
 
-## run.with_mock_db: 🧪 Runs certifier with mock DB
+## run.with_mock_db: 🧪 Runs Talos Certifier with mock DB in release mode
 run.with_mock_db:
 	$(call pp,run app...)
 	cargo run -r --example certifier_kafka_dbmock
 
-## dev.preload_db: 🧪 Injects initial data into DB if it's not there yet
-dev.preload_db:
-	$(call pp,run preload_db...)
-	cargo run --bin preload_db -- $(args)
+## cohort_banking.create_db: 🥁 Creates database for Cohort Banking and applies DB sql
+cohort_banking.create_db:
+	$(call pp,creating database for cohort...)
+	cargo run --package cohort_banking --bin run_db_migrations create-db migrate-db
 
-## dev.cohort_banking: 🧪 Runs Cohort with built-in replicator and executes banking transactions
-dev.cohort_banking:
-	$(call pp,run cohort_banking...)
-	cargo run --example cohort_banking --release -- $(args)
+## cohort_banking.migrate_db: 🥁 Run sdatabase migrations for Cohort Banking
+cohort_banking.migrate_db:
+	$(call pp,running migrations on banking database for cohort...)
+	cargo run --package cohort_banking --bin run_db_migrations
 
-## dev.cohort_banking_with_sdk: 🧪 Runs an example of rust app "Cohort Banking" which use cohort_sdk.
-dev.cohort_banking_with_sdk:
-	$(call pp,run cohort_banking...)
+## cohort_banking.preload_db: 🧪 Injects initial data into Cohort Banking DB
+cohort_banking.preload_db:
+	$(call pp,populating banking database for cohort...)
+	cargo run --package cohort_banking --bin preload_db -- $(args)
+
+## cohort_banking.run_initiator_load_test_in_rust: 🧪 Executes load test through Cohort Initiator implemented in Rust
+cohort_banking.run_initiator_load_test_in_rust:
+	$(call pp,running "Cohort Initiator" implemented in Rust...)
 	cargo run --example cohort_banking_with_sdk --release -- $(args)
+
+## cohort_banking.run_replicator_rust: 🧪 Rust Cohort Banking Replicator implemented in Rust
+cohort_banking.run_replicator_rust:
+	$(call pp,running "Cohort Replicator" implemented in Rust...)
+	cargo run --example cohort_replicator_kafka_pg --release -- $(args)
+
+## cohort_banking.run_initiator_js: 🧪 Executes load test through Cohort Initiator implemented in JS
+cohort_banking.run_initiator_load_test_in_js:
+	$(call pp,running "Cohort Initiator" implemented in JS...)
+	cd ./cohort_banking_initiator_js
+	npm start -- $(args)
+
+## cohort_banking.run_replicator_js: 🧪 Runs Replicator JS app
+cohort_banking.run_replicator_js:
+	$(call pp,running "Cohort Replicator" implemented in JS...)
+	cd ./cohort_banking_replicator_js
+	npm start
 
 ## dev.histogram_decision_timeline_from_kafka: 🧪 Reads all decisions from kafka and prints processing timeline as csv
 dev.histogram_decision_timeline_from_kafka:
 	$(call pp,histogram_decision_timeline_from_kafka...)
 	cargo run --bin histogram_decision_timeline_from_kafka --release -- $(args)
-
-## example.replicator_kafka_pg: 🧪 Runs the example replicator with installer for Kafka and Postgres
-example.replicator_kafka_pg:
-	$(call pp,run app...)
-	cargo run -r --example cohort_replicator_kafka_pg
-
-## dev.run_replicator: 🧪 Runs replicator
-dev.run_replicator:
-	$(call pp,run replicator...)
-	cargo run --bin replicator --release
-
-## dev.run_initiator_js: 🧪 Runs Initiator JS app
-dev.run_initiator_js:
-	$(call pp,run Initiator JS...)
-	cd ./cohort_banking_initiator_js
-	npm start
-
-## dev.run_replicator_js: 🧪 Runs Replicator JS app
-dev.run_replicator_js:
-	$(call pp,run Replicator JS...)
-	cd ./cohort_banking_replicator_js
-	npm start
 
 ## lint: 🧹 Checks for lint failures on rust
 lint:

--- a/examples/cohort_replicator_kafka_pg/examples/cohort_replicator_kafka_pg.rs
+++ b/examples/cohort_replicator_kafka_pg/examples/cohort_replicator_kafka_pg.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use banking_common::state::postgres::{
-    database::{Database, DatabaseError},
+    database::{Database, DatabaseError, SNAPSHOT_SINGLETON_ROW_ID},
     database_config::DatabaseConfig,
 };
 use banking_replicator::{app::BankingReplicatorApp, statemap_installer::BankStatemapInstaller};
@@ -11,8 +11,6 @@ use talos_cohort_replicator::{callbacks::ReplicatorSnapshotProvider, CohortRepli
 use talos_common_utils::{env_var, env_var_with_defaults};
 use talos_rdkafka_utils::kafka_config::KafkaConfig;
 use tokio::signal;
-
-pub static SNAPSHOT_SINGLETON_ROW_ID: &str = "SINGLETON";
 
 pub struct SnapshotApi {
     db: Arc<Database>,

--- a/packages/banking_common/Cargo.toml
+++ b/packages/banking_common/Cargo.toml
@@ -15,7 +15,8 @@ rust_decimal =      { version = "1.30.0", features = ["db-tokio-postgres", "serd
 strum =             { version = "0.25", features = ["derive"] }
 
 # Postgres
-refinery =          { version = "0.8.7", features = ["tokio-postgres"] }
 tokio-postgres =    { version = "0.7", features = [ "with-uuid-1", "with-serde_json-1" ] }
 deadpool =          { version = "0.9.5" }
 deadpool-postgres = { version = "0.10" }
+
+talos_common_utils = { path = "../talos_common_utils" }

--- a/packages/banking_common/src/state/postgres/database_config.rs
+++ b/packages/banking_common/src/state/postgres/database_config.rs
@@ -1,3 +1,5 @@
+use talos_common_utils::{env_var, env_var_with_defaults};
+
 #[derive(Clone, Debug)]
 pub struct DatabaseConfig {
     pub pool_size: u32,
@@ -9,6 +11,18 @@ pub struct DatabaseConfig {
 }
 
 impl DatabaseConfig {
+    pub fn from_env(prefix: Option<&'static str>) -> Result<Self, String> {
+        let prefix = if let Some(prefix) = prefix { format!("{}_", prefix) } else { "".into() };
+        Ok(Self {
+            pool_size: env_var_with_defaults!(format!("{}PG_POOL_SIZE", prefix), u32, 10),
+            host: env_var_with_defaults!(format!("{}PG_HOST", prefix), String, "127.0.0.1".into()),
+            port: env_var!(format!("{}PG_PORT", prefix)),
+            user: env_var!(format!("{}PG_USER", prefix)),
+            password: env_var!(format!("{}PG_PASSWORD", prefix)),
+            database: env_var!(format!("{}PG_DATABASE", prefix)),
+        })
+    }
+
     pub fn get_connection_string(&self, database: &str) -> String {
         format!("postgres://{}:{}@{}:{}/{}", self.user, self.password, self.host, self.port, database)
     }

--- a/packages/cohort_banking/Cargo.toml
+++ b/packages/cohort_banking/Cargo.toml
@@ -17,11 +17,11 @@ opentelemetry_api = { version = "0.20.0" }
 opentelemetry_sdk = { version = "0.20.0", features = ["metrics", "rt-tokio"] }
 opentelemetry =     { version = "0.20.0" }
 rand =              { version = "0.8.5" }
-strum =             { version = "0.25", features = ["derive"] }
-uuid =              { version = "1.2.2", features = ["v4"] }
-
+refinery =          { version = "0.8.7", features = ["tokio-postgres"] }
 rust_decimal =      { version = "1.30.0", features = ["db-tokio-postgres", "serde-with-float"] }
+strum =             { version = "0.25", features = ["derive"] }
 tokio-postgres =    { version = "0.7", features = [ "with-uuid-1", "with-serde_json-1" ] }
+uuid =              { version = "1.2.2", features = ["v4"] }
 
 cohort_sdk =                 { path = "../cohort_sdk" }
 banking_common =             { path = "../banking_common" }
@@ -29,4 +29,5 @@ talos_agent =                { path = "../talos_agent" }
 metrics =                    { path = "../metrics" }
 talos_certifier =            { path = "../talos_certifier" }
 talos_cohort_replicator =    { path = "../talos_cohort_replicator" }
+talos_common_utils =         { path = "../talos_common_utils" }
 talos_suffix =               { path = "../talos_suffix" }

--- a/packages/cohort_banking/src/bin/preload_db.rs
+++ b/packages/cohort_banking/src/bin/preload_db.rs
@@ -1,0 +1,164 @@
+use std::{env, sync::Arc};
+
+use banking_common::state::postgres::{
+    database::{Database, DatabaseError, SNAPSHOT_SINGLETON_ROW_ID},
+    database_config::DatabaseConfig,
+};
+use cohort_banking::model::{bank_account::BankAccount, snapshot::Snapshot};
+use rust_decimal::Decimal;
+use tokio_postgres::Row;
+
+#[tokio::main]
+async fn main() -> Result<(), String> {
+    env_logger::builder().format_timestamp_millis().init();
+
+    let accounts_file = get_params().await?;
+
+    let cfg_db = DatabaseConfig::from_env(Some("COHORT"))?;
+
+    let database = Database::init_db(cfg_db).await.map_err(|e| e.to_string())?;
+
+    prefill_db(accounts_file, Arc::clone(&database)).await;
+
+    Ok(())
+}
+
+async fn prefill_db(accounts_file: String, db: Arc<Database>) {
+    let data = tokio::fs::read_to_string(&accounts_file).await.unwrap();
+    let accounts: Vec<BankAccount> = serde_json::from_str::<Vec<BankAccount>>(&data)
+        .map_err(|e| {
+            log::error!("Unable to read initial data for accounts: {}", e);
+        })
+        .unwrap();
+
+    // Init database ...
+    let updated_accounts = prefill_accounts(Arc::clone(&db), accounts.clone())
+        .await
+        .expect("Unable to prefill accounts table");
+    let updated_snapshot = prefill_snapshot(Arc::clone(&db), Snapshot { version: 0 })
+        .await
+        .expect("Unable to prefil snapshot table");
+
+    log::info!("----------------------------------");
+    log::info!("Initial state is loaded into DB files");
+    log::info!("{}", updated_snapshot);
+    log::info!("Accounts: {}", updated_accounts.len());
+    log::info!("----------------------------------");
+}
+
+async fn prefill_snapshot(db: Arc<Database>, snapshot: Snapshot) -> Result<Snapshot, DatabaseError> {
+    let rslt = db
+        .query_opt(
+            r#"SELECT "version" FROM cohort_snapshot WHERE id = $1 AND "version" > $2"#,
+            &[&SNAPSHOT_SINGLETON_ROW_ID, &(snapshot.version as i64)],
+            snapshot_from_row,
+        )
+        .await?;
+
+    if let Some(snapshot) = rslt {
+        Ok(snapshot)
+    } else {
+        db.query_one(
+            r#"
+                INSERT INTO cohort_snapshot ("id", "version") VALUES ($1, $2)
+                ON CONFLICT(id) DO
+                    UPDATE SET version = $2 RETURNING version
+            "#,
+            &[&SNAPSHOT_SINGLETON_ROW_ID, &(snapshot.version as i64)],
+            snapshot_from_row,
+        )
+        .await
+    }
+}
+
+async fn prefill_accounts(db: Arc<Database>, accounts: Vec<BankAccount>) -> Result<Vec<BankAccount>, DatabaseError> {
+    let client = db.pool.get().await.unwrap();
+    let mut updated_accounts = Vec::<BankAccount>::new();
+    let frequency: u64 = (accounts.len() as f32 * 15.0 / 100.0) as u64;
+    for acc in accounts.iter() {
+        let updated = {
+            let rslt = client
+                .query_opt(
+                    r#"SELECT "name", "number", "amount", "version" FROM bank_accounts WHERE "number" = $1 AND "version" >= $2"#,
+                    &[&acc.number, &(acc.version as i64)],
+                )
+                .await
+                .unwrap();
+
+            if rslt.is_some() {
+                account_from_row(&rslt.unwrap())?
+            } else {
+                // update db with new account data
+                let updated_row = client
+                    .query_one(
+                        r#"
+                            INSERT INTO bank_accounts("name", "number", "amount", "version") VALUES ($1, $2, $3, $4)
+                            ON CONFLICT(number) DO
+                                UPDATE SET "name" = $1, "amount" = $3, "version" = $4 RETURNING "name", "number", "amount", "version"
+                        "#,
+                        &[&acc.name, &acc.number, &acc.balance, &(acc.version as i64)],
+                    )
+                    .await
+                    .unwrap();
+
+                account_from_row(&updated_row)?
+            }
+        };
+
+        if updated_accounts.len() as f32 % frequency as f32 == 0.0 {
+            log::warn!("Inserted: {} accounts of {}", updated_accounts.len(), accounts.len());
+        }
+
+        updated_accounts.push(updated);
+    }
+
+    Ok(updated_accounts)
+}
+
+fn account_from_row(row: &Row) -> Result<BankAccount, DatabaseError> {
+    Ok(BankAccount {
+        name: row
+            .try_get::<&str, String>("name")
+            .map_err(|e| DatabaseError::deserialise_payload(e.to_string(), "Cannot read account name".into()))?,
+        number: row
+            .try_get::<&str, String>("number")
+            .map_err(|e| DatabaseError::deserialise_payload(e.to_string(), "Cannot read account number".into()))?,
+        version: row
+            .try_get::<&str, i64>("version")
+            .map_err(|e| DatabaseError::deserialise_payload(e.to_string(), "Cannot read account version".into()))? as u64,
+        balance: row
+            .try_get::<&str, Decimal>("amount")
+            .map_err(|e| DatabaseError::deserialise_payload(e.to_string(), "Cannot read account amount".into()))?,
+    })
+}
+
+fn snapshot_from_row(row: &Row) -> Result<Snapshot, DatabaseError> {
+    let updated = row
+        .try_get::<&str, i64>("version")
+        .map_err(|e| DatabaseError::deserialise_payload(e.to_string(), "Cannot read snapshot".into()))?;
+
+    Ok(Snapshot { version: updated as u64 })
+}
+
+async fn get_params() -> Result<String, String> {
+    let args: Vec<String> = env::args().collect();
+    let mut accounts_file: Option<String> = None;
+
+    if args.len() >= 3 {
+        let mut i = 1;
+        while i < args.len() {
+            let param_name = &args[i];
+
+            if param_name.eq("--accounts") {
+                let param_value = &args[i + 1];
+                accounts_file = Some((*param_value).clone());
+            }
+
+            i += 2;
+        }
+    } else {
+        log::warn!("Missing paramters:\n  --accounts 'path-to-json'")
+    }
+
+    Ok(accounts_file.unwrap())
+}

--- a/packages/cohort_banking/src/bin/run_db_migrations.rs
+++ b/packages/cohort_banking/src/bin/run_db_migrations.rs
@@ -1,0 +1,97 @@
+use std::env;
+
+use banking_common::state::postgres::database_config::DatabaseConfig;
+use tokio_postgres::error::SqlState;
+use tokio_postgres::Client;
+
+mod embedded {
+    refinery::embed_migrations!("./src/bin/sql");
+}
+
+#[tokio::main]
+async fn main() -> Result<(), String> {
+    env_logger::builder().format_timestamp_millis().init();
+
+    let args: Vec<String> = env::args().collect();
+    let mut should_migrate = false;
+    let mut should_create_db = false;
+    if args.len() == 1 {
+        should_migrate = true;
+    } else {
+        for arg in args.iter() {
+            should_migrate |= arg == "migrate-db";
+            should_create_db |= arg == "create-db";
+        }
+    }
+
+    if !should_create_db && !should_migrate {
+        panic!("Missing arguments. Specify 'migrate-db' or 'create-db' or both.");
+    }
+
+    let cfg = DatabaseConfig::from_env(Some("COHORT"))?;
+
+    if should_create_db {
+        create_db(&cfg).await?;
+    }
+    if should_migrate {
+        migrate_schema(&cfg).await?;
+    }
+
+    Ok(())
+}
+
+async fn create_db(cfg: &DatabaseConfig) -> Result<(), String> {
+    let rslt = connect(cfg.get_connection_string(&cfg.database).as_str()).await;
+    if let Err(pg_error) = rslt {
+        return if let Some(&SqlState::UNDEFINED_DATABASE) = pg_error.code() {
+            let url = cfg.get_connection_string("");
+            let client = connect(url.as_str()).await.unwrap();
+            client.execute(&format!("CREATE DATABASE \"{}\" ", cfg.database), &[]).await.unwrap();
+            log::info!("Created database: '{}'", &cfg.database);
+            Ok(())
+        } else {
+            Err(format!(
+                "Cannot connect to database using this url: '{}'. Error: {}",
+                &cfg.get_public_connection_string(&cfg.database),
+                pg_error,
+            ))
+        };
+    }
+
+    log::info!("Database '{}' already exists.", cfg.database);
+    Ok(())
+}
+
+async fn migrate_schema(cfg: &DatabaseConfig) -> Result<(), String> {
+    let url = cfg.get_connection_string(&cfg.database);
+    let rslt = connect(url.as_str()).await;
+    if let Err(e) = rslt {
+        return Err(format!(
+            "Cannot to connect to database using this url: '{}'. Error: {}",
+            cfg.get_public_connection_string(&cfg.database),
+            e,
+        ));
+    }
+
+    let mut client = rslt.unwrap();
+
+    let runner = embedded::migrations::runner();
+    let migration_report = runner.run_async(&mut client).await.unwrap();
+    for migration in migration_report.applied_migrations() {
+        log::info!("Migration Applied -  Name: {}, Version: {}", migration.name(), migration.version());
+    }
+    log::info!("DB sql finished!");
+
+    Ok(())
+}
+
+async fn connect(connection_string: &str) -> Result<Client, tokio_postgres::Error> {
+    let (client, connection) = tokio_postgres::connect(connection_string, tokio_postgres::NoTls).await?;
+
+    tokio::spawn(async move {
+        if let Err(e) = connection.await {
+            eprintln!("connection error: {}", e);
+        }
+    });
+    Ok(client)
+}

--- a/packages/cohort_banking/src/bin/sql/V1__create_tables.sql
+++ b/packages/cohort_banking/src/bin/sql/V1__create_tables.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS bank_accounts (
+	"number" VARCHAR(20) NOT NULL,
+	"name" VARCHAR(20) NOT NULL,
+	amount NUMERIC(20, 5) NOT NULL,
+	"version" BIGINT NOT NULL,
+	CONSTRAINT bank_accounts_pkey PRIMARY KEY (NUMBER)
+);
+
+CREATE TABLE IF NOT EXISTS cohort_snapshot (
+    "id"        CHAR(9) PRIMARY KEY,       -- The value is always 'SINGLETON'
+	"version"   BIGINT NOT NULL
+);

--- a/packages/cohort_banking/src/callbacks/oo_installer.rs
+++ b/packages/cohort_banking/src/callbacks/oo_installer.rs
@@ -16,8 +16,6 @@ pub struct OutOfOrderInstallerImpl {
     pub single_query_strategy: bool,
 }
 
-pub static SNAPSHOT_SINGLETON_ROW_ID: &str = "SINGLETON";
-
 impl OutOfOrderInstallerImpl {
     async fn install_using_single_query(
         &self,


### PR DESCRIPTION
Changes made in the Make file are not easy to read in this PR ui. Here how commands look like now:


```
/Users/marekfedorovic/kindred/projects/talos-certifier-git $ make
 Choose a command to run:
  withenv                                          😭 CALL TARGETS LIKE THIS `make withenv RECIPE=dev.init`
  dev.init                                         🌏 Initialize local dev environment
  dev.kafka_init                                   🥁 Init kafka topic
  pg.create                                        🥁 Create database
  pg.migrate                                       🥁 Run sql on database
  install                                          🧹 Installs dependencies
  build                                            🧪 Compiles rust
  init.samply                                      🧪 Installs Samply profiler
  init.flamegraph                                  🧪 Installs Flamegraph profiler
  agent.run-client                                 🧪 Executes load test through Talos Agent
  agent.run-profiler-samply                        🧪 Runs agent with Samply profiler
  agent.run-profiler-flamegraph                    🧪 Runs agent with Flamegraph profiler
  agent.run-profiler-xcode-cpu                     🧪 Runs agent with XCode profiler for Time (CPU) Profiler (OSX only)
  agent.run-profiler-xcode-mem                     🧪 Runs agent with XCode profiler for Allocations (OSX only)
  dev.run                                          🧪 Runs Talos Certifier app in watch mode
  run                                              🧪 Runs Talos Certifier app
  run.release                                      🧪 Runs Talos Certifier app in release mode
  run.with_mock_db                                 🧪 Runs Talos Certifier with mock DB in release mode
  cohort_banking.create_db                         🥁 Creates database for Cohort Banking and applies DB sql
  cohort_banking.migrate_db                        🥁 Run sdatabase migrations for Cohort Banking
  cohort_banking.preload_db                        🧪 Injects initial data into Cohort Banking DB
  cohort_banking.run_initiator_load_test_in_rust   🧪 Executes load test through Cohort Initiator implemented in Rust
  cohort_banking.run_replicator_rust               🧪 Rust Cohort Banking Replicator implemented in Rust
  cohort_banking.run_initiator_js                  🧪 Executes load test through Cohort Initiator implemented in JS
  cohort_banking.run_replicator_js                 🧪 Runs Replicator JS app
  dev.histogram_decision_timeline_from_kafka       🧪 Reads all decisions from kafka and prints processing timeline as csv
  lint                                             🧹 Checks for lint failures on rust
  test.unit                                        🧪 Runs unit tests
  test.some-unit                                   🧪 Runs specified unit tests
  test.unit.coverage                               🧪 Runs rust unit tests with coverage 'cobertura' and 'junit' reports
```