### PR TITLE
feat: final tweaks to messenger

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,5 +71,8 @@ BANK_REPLICATOR_KAFKA_GROUP_ID="talos-replicator-dev"
 BANK_STATEMAP_INSTALLER_MAX_RETRY=5
 BANK_STATEMAP_INSTALL_RETRY_WAIT_MS=2
 
+# ### Talos Messenger Env variables (start) #############################
 # Messenger environment variables
 TALOS_MESSENGER_KAFKA_GROUP_ID="talos-messenger-dev"
+TALOS_MESSENGER_ACTIONS_WHITELIST="publish:kafka"
+# ### Talos Messenger Env variables (end) #############################

--- a/examples/agent_client/examples/agent_client.rs
+++ b/examples/agent_client/examples/agent_client.rs
@@ -275,18 +275,15 @@ async fn get_params() -> Result<LaunchParams, String> {
         }
     }
 
-    if stop_type.is_none() {
-        Err("Parameter --volume is required".into())
-    } else if target_rate.is_none() {
-        Err("Parameter --rate is required".into())
-    } else {
-        Ok(LaunchParams {
-            target_rate: target_rate.unwrap(),
-            stop_type: stop_type.unwrap(),
-            threads: threads.unwrap(),
-            collect_metrics: collect_metrics.unwrap(),
-        })
-    }
+    let stop_type = stop_type.ok_or("Parameter --volume is required")?;
+    let target_rate = target_rate.ok_or("Parameter --rate is required")?;
+
+    Ok(LaunchParams {
+        target_rate,
+        stop_type,
+        threads: threads.unwrap(),
+        collect_metrics: collect_metrics.unwrap(),
+    })
 }
 
 struct RequestGenerator {}

--- a/examples/cohort_banking_with_sdk/examples/cohort_banking_with_sdk.rs
+++ b/examples/cohort_banking_with_sdk/examples/cohort_banking_with_sdk.rs
@@ -263,22 +263,18 @@ async fn get_params() -> Result<LaunchParams, String> {
         }
     }
 
-    if stop_type.is_none() {
-        Err("Parameter --volume is required".into())
-    } else if accounts.is_none() {
-        Err("Parameter --accounts is required".into())
-    } else if target_rate.is_none() {
-        Err("Parameter --rate is required".into())
-    } else {
-        Ok(LaunchParams {
-            target_rate: target_rate.unwrap(),
-            stop_type: stop_type.unwrap(),
-            threads: threads.unwrap(),
-            accounts: accounts.unwrap(),
-            scaling_config: scaling_config.unwrap_or(HashMap::new()),
-            metric_print_raw: metric_print_raw.is_some(),
-        })
-    }
+    let stop_type = stop_type.ok_or("Parameter --volume is required")?;
+    let target_rate = target_rate.ok_or("Parameter --rate is required")?;
+    let accounts = accounts.ok_or("Parameter --accounts is required")?;
+
+    Ok(LaunchParams {
+        target_rate,
+        stop_type,
+        threads: threads.unwrap(),
+        accounts,
+        scaling_config: scaling_config.unwrap_or_default(),
+        metric_print_raw: metric_print_raw.is_some(),
+    })
 }
 
 struct TransferRequestGenerator {

--- a/examples/messenger_using_kafka/examples/messenger_using_kafka.rs
+++ b/examples/messenger_using_kafka/examples/messenger_using_kafka.rs
@@ -1,9 +1,13 @@
-use ahash::{HashMap, HashMapExt};
 use talos_certifier::ports::MessageReciever;
 use talos_certifier_adapters::KafkaConsumer;
 use talos_common_utils::env_var;
 use talos_messenger_actions::kafka::{context::MessengerProducerContext, producer::KafkaProducer, service::KafkaActionService};
-use talos_messenger_core::{services::MessengerInboundService, suffix::MessengerCandidate, talos_messenger_service::TalosMessengerService};
+use talos_messenger_core::{
+    services::MessengerInboundService,
+    suffix::MessengerCandidate,
+    talos_messenger_service::TalosMessengerService,
+    utlis::{create_whitelist_actions_from_str, ActionsParserConfig},
+};
 use talos_rdkafka_utils::kafka_config::KafkaConfig;
 use talos_suffix::{core::SuffixConfig, Suffix};
 use tokio::sync::mpsc;
@@ -46,20 +50,16 @@ async fn main() {
     };
     let suffix: Suffix<MessengerCandidate> = Suffix::with_config(suffix_config);
 
-    let mut whitelisted_actions = HashMap::<&'static str, Vec<&'static str>>::new();
-    // TODO: GK - Set through env
-    whitelisted_actions.insert("publish", vec!["kafka"]);
+    let actions_from_env = env_var!("TALOS_MESSENGER_ACTIONS_WHITELIST");
+    let allowed_actions = create_whitelist_actions_from_str(&actions_from_env, &ActionsParserConfig::default());
 
     let inbound_service = MessengerInboundService {
         message_receiver: kafka_consumer,
         tx_actions_channel,
         rx_feedback_channel,
         suffix,
-        allowed_actions: whitelisted_actions,
+        allowed_actions,
     };
-
-    // TODO: GK - create topic should be part of publish.
-    kafka_config.topic = "test.messenger.topic".to_string();
 
     let tx_feedback_channel_clone = tx_feedback_channel.clone();
     let custom_context = MessengerProducerContext {

--- a/examples/messenger_using_kafka/examples/messenger_using_kafka.rs
+++ b/examples/messenger_using_kafka/examples/messenger_using_kafka.rs
@@ -69,7 +69,7 @@ async fn main() {
     let messenger_kafka_publisher = MessengerKafkaPublisher { publisher: kafka_producer };
 
     let publish_service = KafkaActionService {
-        publisher: messenger_kafka_publisher,
+        publisher: messenger_kafka_publisher.into(),
         rx_actions_channel,
         tx_feedback_channel,
     };

--- a/examples/messenger_using_kafka/examples/messenger_using_kafka.rs
+++ b/examples/messenger_using_kafka/examples/messenger_using_kafka.rs
@@ -2,10 +2,7 @@ use ahash::{HashMap, HashMapExt};
 use talos_certifier::ports::MessageReciever;
 use talos_certifier_adapters::KafkaConsumer;
 use talos_common_utils::env_var;
-use talos_messenger_actions::kafka::{
-    producer::{KafkaProducer, MessengerKafkaProducerContext},
-    service::KafkaActionService,
-};
+use talos_messenger_actions::kafka::{context::MessengerProducerContext, producer::KafkaProducer, service::KafkaActionService};
 use talos_messenger_core::{services::MessengerInboundService, suffix::MessengerCandidate, talos_messenger_service::TalosMessengerService};
 use talos_rdkafka_utils::kafka_config::KafkaConfig;
 use talos_suffix::{core::SuffixConfig, Suffix};
@@ -65,7 +62,7 @@ async fn main() {
     kafka_config.topic = "test.messenger.topic".to_string();
 
     let tx_feedback_channel_clone = tx_feedback_channel.clone();
-    let custom_context = MessengerKafkaProducerContext {
+    let custom_context = MessengerProducerContext {
         tx_feedback_channel: tx_feedback_channel_clone,
     };
     let kafka_producer = KafkaProducer::with_context(&kafka_config, custom_context);

--- a/examples/messenger_using_kafka/src/kafka_producer.rs
+++ b/examples/messenger_using_kafka/src/kafka_producer.rs
@@ -1,10 +1,7 @@
 use async_trait::async_trait;
 use log::info;
 use rdkafka::producer::ProducerContext;
-use talos_messenger_actions::kafka::{
-    models::KafkaAction,
-    producer::{KafkaProducer, MessengerProducerDeliveryOpaque},
-};
+use talos_messenger_actions::kafka::{context::MessengerProducerDeliveryOpaque, models::KafkaAction, producer::KafkaProducer};
 use talos_messenger_core::core::{MessengerPublisher, PublishActionType};
 // use talos_messenger::{
 //     core::{MessengerPublisher, PublishActionType},

--- a/packages/talos_certifier/src/ports/message.rs
+++ b/packages/talos_certifier/src/ports/message.rs
@@ -16,7 +16,7 @@ pub trait MessageReciever: SharedPortTraits {
     async fn subscribe(&self) -> Result<(), SystemServiceError>;
     async fn commit(&self) -> Result<(), SystemServiceError>;
     fn commit_async(&self) -> Option<JoinHandle<Result<(), SystemServiceError>>>;
-    fn update_savepoint(&mut self, offset: i64) -> Result<(), Box<SystemServiceError>>;
+    fn update_offset_to_commit(&mut self, offset: i64) -> Result<(), Box<SystemServiceError>>;
     async fn update_savepoint_async(&mut self, offset: i64) -> Result<(), SystemServiceError>;
     async fn unsubscribe(&self);
 }

--- a/packages/talos_certifier/src/services/message_receiver_service.rs
+++ b/packages/talos_certifier/src/services/message_receiver_service.rs
@@ -84,7 +84,7 @@ impl SystemService for MessageReceiverService {
           //** commit message
           _ = self.commit_interval.tick() => {
             let offset = self.commit_offset.load(std::sync::atomic::Ordering::Relaxed);
-            self.receiver.update_savepoint(offset)?;
+            self.receiver.update_offset_to_commit(offset)?;
             self.receiver.commit_async();
           }
         }

--- a/packages/talos_certifier/src/services/tests/message_receiver_service.rs
+++ b/packages/talos_certifier/src/services/tests/message_receiver_service.rs
@@ -47,7 +47,7 @@ impl MessageReciever for MockReciever {
     fn commit_async(&self) -> Option<JoinHandle<Result<(), SystemServiceError>>> {
         None
     }
-    fn update_savepoint(&mut self, _version: i64) -> Result<(), Box<SystemServiceError>> {
+    fn update_offset_to_commit(&mut self, _version: i64) -> Result<(), Box<SystemServiceError>> {
         Ok(())
     }
     async fn update_savepoint_async(&mut self, _version: i64) -> Result<(), SystemServiceError> {

--- a/packages/talos_certifier_adapters/src/kafka/consumer.rs
+++ b/packages/talos_certifier_adapters/src/kafka/consumer.rs
@@ -206,7 +206,7 @@ impl MessageReciever for KafkaConsumer {
         }
     }
 
-    fn update_savepoint(&mut self, offset: i64) -> Result<(), Box<SystemServiceError>> {
+    fn update_offset_to_commit(&mut self, offset: i64) -> Result<(), Box<SystemServiceError>> {
         // let partition = self.tpl.;
         let tpl = self.tpl.elements_for_topic(&self.topic);
         if !tpl.is_empty() {

--- a/packages/talos_cohort_replicator/src/core.rs
+++ b/packages/talos_cohort_replicator/src/core.rs
@@ -141,7 +141,7 @@ where
 
     pub(crate) async fn commit(&mut self) {
         if let Some(version) = self.next_commit_offset {
-            self.receiver.update_savepoint(version as i64).unwrap();
+            self.receiver.update_offset_to_commit(version as i64).unwrap();
             self.receiver.commit_async();
             self.next_commit_offset = None;
         }

--- a/packages/talos_messenger_actions/src/kafka/context.rs
+++ b/packages/talos_messenger_actions/src/kafka/context.rs
@@ -1,0 +1,42 @@
+use futures_executor::block_on;
+use log::info;
+use rdkafka::{producer::ProducerContext, ClientContext, Message};
+use talos_messenger_core::core::MessengerChannelFeedback;
+use tokio::sync::mpsc;
+
+#[derive(Debug)]
+pub struct MessengerProducerDeliveryOpaque {
+    pub version: u64,
+    pub total_publish_count: u32,
+}
+
+pub struct MessengerProducerContext {
+    pub tx_feedback_channel: mpsc::Sender<MessengerChannelFeedback>,
+}
+
+impl ClientContext for MessengerProducerContext {}
+impl ProducerContext for MessengerProducerContext {
+    type DeliveryOpaque = Box<MessengerProducerDeliveryOpaque>;
+
+    fn delivery(&self, delivery_result: &rdkafka::producer::DeliveryResult<'_>, delivery_opaque: Self::DeliveryOpaque) {
+        let result = delivery_result.as_ref();
+
+        let version = delivery_opaque.version;
+
+        match result {
+            Ok(msg) => {
+                info!("Message {:?} {:?}", msg.key(), msg.offset());
+                // TODO: GK - what to do on error? Panic?
+                let _ = block_on(self.tx_feedback_channel.send(MessengerChannelFeedback::Success(
+                    version,
+                    "kafka".to_string(),
+                    delivery_opaque.total_publish_count,
+                )));
+            }
+            Err(err) => {
+                // TODO: GK - what to do on error? Panic?
+                let _ = block_on(self.tx_feedback_channel.send(MessengerChannelFeedback::Error(version, err.0.to_string())));
+            }
+        }
+    }
+}

--- a/packages/talos_messenger_actions/src/kafka/context.rs
+++ b/packages/talos_messenger_actions/src/kafka/context.rs
@@ -26,7 +26,7 @@ impl ProducerContext for MessengerProducerContext {
         match result {
             Ok(msg) => {
                 info!("Message {:?} {:?}", msg.key(), msg.offset());
-                // TODO: GK - what to do on error? Panic?
+                // Safe to ignore error check, as error occurs only if receiver is closed or dropped, which would happen if the thread receving has errored. In such a scenario, the publisher thread would also shutdown.
                 let _ = block_on(self.tx_feedback_channel.send(MessengerChannelFeedback::Success(
                     version,
                     "kafka".to_string(),
@@ -34,7 +34,7 @@ impl ProducerContext for MessengerProducerContext {
                 )));
             }
             Err(err) => {
-                // TODO: GK - what to do on error? Panic?
+                // Safe to ignore error check, as error occurs only if receiver is closed or dropped, which would happen if the thread receving has errored. In such a scenario, the publisher thread would also shutdown.
                 let _ = block_on(self.tx_feedback_channel.send(MessengerChannelFeedback::Error(version, err.0.to_string())));
             }
         }

--- a/packages/talos_messenger_actions/src/kafka/mod.rs
+++ b/packages/talos_messenger_actions/src/kafka/mod.rs
@@ -1,3 +1,4 @@
+pub mod context;
 pub mod models;
 pub mod producer;
 pub mod service;

--- a/packages/talos_messenger_actions/src/kafka/models.rs
+++ b/packages/talos_messenger_actions/src/kafka/models.rs
@@ -2,14 +2,41 @@ use ahash::HashMap;
 use serde::{Deserialize, Serialize}; // 1.0.130
 use serde_json::{self};
 
+fn default_text_plain_encoding() -> String {
+    "text/plain".to_string()
+}
+
+fn default_application_json_encoding() -> String {
+    "application/json".to_string()
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
+pub struct MessengerKafkaActionHeader {
+    pub key_encoding: String,
+    pub key: String,
+    pub value_encoding: String,
+    pub value: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub struct KafkaAction {
-    // TODO: GK - Add additional Kafka producer related props here.
-    // pub version: u32,
-    // pub cluster: String,
+    #[serde(default)]
+    pub cluster: String,
+    /// Topic to publish the payload
     pub topic: String,
+    /// Key encoding to be used. Defaults to `text/plain`.
+    #[serde(default = "default_text_plain_encoding")]
+    pub key_encoding: String,
+    /// Key for the message to publish.
     pub key: Option<String>,
+    /// Optional if the message should be published to a specific partition.
     pub partition: Option<i32>,
+    /// Optional headers while publishing.
     pub headers: Option<HashMap<String, String>>,
+    /// Key encoding to be used. Defaults to `application/json`.
+    #[serde(default = "default_application_json_encoding")]
+    pub value_encoding: String,
+    /// Payload to publish.
     pub value: serde_json::Value,
 }

--- a/packages/talos_messenger_actions/src/kafka/models.rs
+++ b/packages/talos_messenger_actions/src/kafka/models.rs
@@ -5,6 +5,8 @@ use serde_json::{self};
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub struct KafkaAction {
     // TODO: GK - Add additional Kafka producer related props here.
+    // pub version: u32,
+    // pub cluster: String,
     pub topic: String,
     pub key: Option<String>,
     pub partition: Option<i32>,

--- a/packages/talos_messenger_actions/src/kafka/producer.rs
+++ b/packages/talos_messenger_actions/src/kafka/producer.rs
@@ -14,7 +14,6 @@ use talos_certifier_adapters::kafka::utils::build_kafka_headers;
 use talos_rdkafka_utils::kafka_config::KafkaConfig;
 
 // Kafka Producer
-// #[derive(Clone)]
 pub struct KafkaProducer<C: ProducerContext + 'static = DefaultProducerContext> {
     producer: ThreadedProducer<C>,
     topic: String,

--- a/packages/talos_messenger_actions/src/kafka/producer.rs
+++ b/packages/talos_messenger_actions/src/kafka/producer.rs
@@ -1,11 +1,10 @@
 use std::collections::HashMap;
 
 use async_trait::async_trait;
-use log::{debug, info};
+use log::debug;
 use rdkafka::{
     config::{FromClientConfig, FromClientConfigAndContext},
     producer::{BaseRecord, DefaultProducerContext, ProducerContext, ThreadedProducer},
-    ClientContext, Message,
 };
 use talos_certifier::{
     errors::SystemServiceError,
@@ -13,47 +12,6 @@ use talos_certifier::{
 };
 use talos_certifier_adapters::kafka::utils::build_kafka_headers;
 use talos_rdkafka_utils::kafka_config::KafkaConfig;
-use tokio::sync::mpsc;
-
-use futures_executor::block_on;
-use talos_messenger_core::core::MessengerChannelFeedback;
-
-#[derive(Debug)]
-pub struct MessengerProducerDeliveryOpaque {
-    pub version: u64,
-    pub total_publish_count: u32,
-}
-
-pub struct MessengerKafkaProducerContext {
-    pub tx_feedback_channel: mpsc::Sender<MessengerChannelFeedback>,
-}
-
-impl ClientContext for MessengerKafkaProducerContext {}
-impl ProducerContext for MessengerKafkaProducerContext {
-    type DeliveryOpaque = Box<MessengerProducerDeliveryOpaque>;
-
-    fn delivery(&self, delivery_result: &rdkafka::producer::DeliveryResult<'_>, delivery_opaque: Self::DeliveryOpaque) {
-        let result = delivery_result.as_ref();
-
-        let version = delivery_opaque.version;
-
-        match result {
-            Ok(msg) => {
-                info!("Message {:?} {:?}", msg.key(), msg.offset());
-                // TODO: GK - what to do on error? Panic?
-                let _ = block_on(self.tx_feedback_channel.send(MessengerChannelFeedback::Success(
-                    version,
-                    "kafka".to_string(),
-                    delivery_opaque.total_publish_count,
-                )));
-            }
-            Err(err) => {
-                // TODO: GK - what to do on error? Panic?
-                let _ = block_on(self.tx_feedback_channel.send(MessengerChannelFeedback::Error(version, err.0.to_string())));
-            }
-        }
-    }
-}
 
 // Kafka Producer
 // #[derive(Clone)]

--- a/packages/talos_messenger_actions/src/kafka/service.rs
+++ b/packages/talos_messenger_actions/src/kafka/service.rs
@@ -31,11 +31,7 @@ where
                 Some(actions) = self.rx_actions_channel.recv() => {
                     let MessengerCommitActions {version, commit_actions } = actions;
 
-                    let Some(publish_actions_for_type) = commit_actions.get(&self.publisher.get_publish_type().to_string()) else {
-                        // If publish is not present, continue the loop.
-                        continue;
-                    };
-
+                    if let Some(publish_actions_for_type) = commit_actions.get(&self.publisher.get_publish_type().to_string())
                     // TODO: GK - Make this block generic in next ticket to iterator in loop by PublishActionType
                     {
                         match  get_actions_deserialised::<Vec<KafkaAction>>(publish_actions_for_type) {

--- a/packages/talos_messenger_actions/src/kafka/service.rs
+++ b/packages/talos_messenger_actions/src/kafka/service.rs
@@ -10,6 +10,7 @@ use talos_messenger_core::{
 
 use super::models::KafkaAction;
 
+#[derive(Debug)]
 pub struct KafkaActionService<M: MessengerPublisher<Payload = KafkaAction> + Send + Sync> {
     pub publisher: M,
     pub rx_actions_channel: mpsc::Receiver<MessengerCommitActions>,

--- a/packages/talos_messenger_actions/src/kafka/service.rs
+++ b/packages/talos_messenger_actions/src/kafka/service.rs
@@ -31,15 +31,13 @@ where
                 Some(actions) = self.rx_actions_channel.recv() => {
                     let MessengerCommitActions {version, commit_actions } = actions;
 
-                    if let Some(publish_actions_for_type) = commit_actions.get(&self.publisher.get_publish_type().to_string())
-                    // TODO: GK - Make this block generic in next ticket to iterator in loop by PublishActionType
-                    {
+                    if let Some(publish_actions_for_type) = commit_actions.get(&self.publisher.get_publish_type().to_string()){
                         match  get_actions_deserialised::<Vec<KafkaAction>>(publish_actions_for_type) {
                             Ok(actions) => {
 
                                 let total_len = actions.len() as u32;
                                 for action in actions {
-                                    // Send to Kafka
+                                    // Publish the message
                                     self.publisher.send(version, action, total_len ).await;
 
                                 }

--- a/packages/talos_messenger_core/src/core.rs
+++ b/packages/talos_messenger_core/src/core.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use strum::{Display, EnumIter, EnumString};
 
-use crate::errors::MessengerServiceResult;
+use crate::errors::{MessengerActionError, MessengerServiceResult};
 
 #[derive(Debug, Display, Serialize, Deserialize, EnumString, EnumIter, Clone, Eq, PartialEq)]
 pub enum CommitActionType {
@@ -34,13 +34,13 @@ pub trait MessengerSystemService {
     async fn stop(&self) -> MessengerServiceResult;
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MessengerCommitActions {
     pub version: u64,
     pub commit_actions: HashMap<String, Value>,
 }
 
 pub enum MessengerChannelFeedback {
-    Error(u64, String),
-    Success(u64, String, u32),
+    Error(u64, String, Box<MessengerActionError>),
+    Success(u64, String),
 }

--- a/packages/talos_messenger_core/src/errors.rs
+++ b/packages/talos_messenger_core/src/errors.rs
@@ -3,13 +3,14 @@ use thiserror::Error as ThisError;
 pub type MessengerServiceResult = Result<(), MessengerServiceError>;
 
 #[derive(Debug, PartialEq, Clone)]
-pub enum ActionErrorKind {
+pub enum MessengerActionErrorKind {
     Deserialisation,
+    Publishing,
 }
 #[derive(Debug, ThisError, PartialEq, Clone)]
-#[error("Action Error {kind:?} with reason={reason} for data={data:?}")]
-pub struct ActionError {
-    pub kind: ActionErrorKind,
+#[error("Messenger action error {kind:?} with reason={reason} for data={data:?}")]
+pub struct MessengerActionError {
+    pub kind: MessengerActionErrorKind,
     pub reason: String,
     pub data: String,
 }

--- a/packages/talos_messenger_core/src/services/inbound_service.rs
+++ b/packages/talos_messenger_core/src/services/inbound_service.rs
@@ -98,10 +98,9 @@ where
                         // Call prune method on suffix.
                         let _ = self.suffix.prune_till_index(index_to_prune);
 
-                        // TODO: GK - Calculate the safe offset to commit.
                         let commit_offset = version + 1;
                         debug!("[Commit] Updating tpl to version .. {commit_offset}");
-                        let _ = self.message_receiver.update_savepoint(commit_offset as i64);
+                        let _ = self.message_receiver.update_offset_to_commit(commit_offset as i64);
 
                         self.message_receiver.commit_async();
                     }

--- a/packages/talos_messenger_core/src/services/inbound_service.rs
+++ b/packages/talos_messenger_core/src/services/inbound_service.rs
@@ -37,7 +37,7 @@ where
     pub tx_actions_channel: mpsc::Sender<MessengerCommitActions>,
     pub rx_feedback_channel: mpsc::Receiver<MessengerChannelFeedback>,
     pub suffix: Suffix<MessengerCandidate>,
-    pub allowed_actions: HashMap<&'static str, Vec<&'static str>>,
+    pub allowed_actions: HashMap<String, Vec<String>>,
 }
 
 impl<M> MessengerInboundService<M>

--- a/packages/talos_messenger_core/src/utlis.rs
+++ b/packages/talos_messenger_core/src/utlis.rs
@@ -6,6 +6,65 @@ use serde_json::Value;
 
 use crate::{errors::ActionError, suffix::AllowedActionsMapItem};
 
+#[derive(Debug, Clone, Copy)]
+pub struct ActionsParserConfig<'a> {
+    pub case_sensitive: bool,
+    pub key_value_delimiter: &'a str,
+}
+
+impl Default for ActionsParserConfig<'_> {
+    fn default() -> Self {
+        Self {
+            case_sensitive: Default::default(),
+            key_value_delimiter: ":",
+        }
+    }
+}
+
+/// Builds the list of items from a comma separated string.
+///
+///
+/// `ActionsParserConfig` can be passed to specify if
+/// - The key and value should be case sensitive. (defaults to false)
+/// - Key-Value delimiter. (defaults to ':')
+pub fn create_whitelist_actions_from_str(whitelist_str: &str, config: &ActionsParserConfig) -> HashMap<String, Vec<String>> {
+    whitelist_str.split(',').fold(HashMap::new(), |mut acc_map, item| {
+        // case sensitive check.
+        let item_cased = if !config.case_sensitive { item.to_lowercase() } else { item.to_string() };
+        // Has a key-value pair
+        if let Some((key, value)) = item_cased.trim().split_once(config.key_value_delimiter) {
+            let key_to_check = if !config.case_sensitive { key.to_lowercase() } else { key.to_owned() };
+            let key_to_check = key_to_check.trim();
+            // update existing entry
+            if let Some(map_item) = acc_map.get_mut(key_to_check) {
+                // Check for duplicate before inserting
+                let value_trimmed = value.trim().to_owned();
+                if !map_item.contains(&value_trimmed) {
+                    map_item.push(value_trimmed)
+                }
+            }
+            // insert new entry
+            else {
+                // Empty value will not be inserted
+                if !value.is_empty() {
+                    acc_map.insert(key.to_owned(), vec![value.to_owned()]);
+                }
+            }
+        }
+        // just key type.
+        else {
+            let insert_key = if config.case_sensitive {
+                item_cased.to_lowercase()
+            } else {
+                item_cased.to_owned()
+            };
+            let key_to_check = insert_key.trim();
+            acc_map.insert(key_to_check.trim().to_owned(), vec![]);
+        }
+        acc_map
+    })
+}
+
 /// Retrieves the serde_json::Value for a given key
 pub fn get_value_by_key<'a>(value: &'a Value, key: &str) -> Option<&'a Value> {
     value.get(key)
@@ -14,10 +73,7 @@ pub fn get_value_by_key<'a>(value: &'a Value, key: &str) -> Option<&'a Value> {
 /// Create a Hashmap of all the actions that require to be actioned by the messenger.
 /// Key for the map is the Action type. eg: "kafka", "mqtt" ..etc
 /// Value for the map contains the payload and some meta information like items actioned, and is completed flag
-pub fn get_allowed_commit_actions(
-    on_commit_actions: &Value,
-    allowed_actions: &HashMap<&'static str, Vec<&'static str>>,
-) -> HashMap<String, AllowedActionsMapItem> {
+pub fn get_allowed_commit_actions(on_commit_actions: &Value, allowed_actions: &HashMap<String, Vec<String>>) -> HashMap<String, AllowedActionsMapItem> {
     let mut filtered_actions = HashMap::new();
 
     allowed_actions.iter().for_each(|(action_key, sub_action_keys)| {
@@ -45,6 +101,8 @@ pub fn get_actions_deserialised<T: DeserializeOwned>(actions: &Value) -> Result<
     }
 }
 
+pub fn parse_white_list() {}
+
 ///// Retrieves the oncommit actions that are supported by the system.
 // fn get_allowed_commit_actions(version: &u64, on_commit_actions: &Value) -> Option<OnCommitActions> {
 //     let Some(publish_actions) = on_commit_actions.get("publish") else {
@@ -52,7 +110,6 @@ pub fn get_actions_deserialised<T: DeserializeOwned>(actions: &Value) -> Result<
 //         return None;
 //     };
 
-//     // TODO: GK - In future we will need to check if there are other type that we are interested in, and not just Kafka
 //     match get_sub_actions::<Vec<KafkaAction>>(version, publish_actions, "kafka") {
 //         Some(kafka_actions) if !kafka_actions.is_empty() => Some(OnCommitActions::Publish(Some(PublishActions::Kafka(kafka_actions)))),
 //         _ => None,

--- a/packages/talos_rdkafka_utils/src/kafka_config.rs
+++ b/packages/talos_rdkafka_utils/src/kafka_config.rs
@@ -109,7 +109,7 @@ impl KafkaConfig {
 
         self.setup_auth(&mut client_config, base_config);
 
-        log::warn!("p: client_config = {:?}", client_config);
+        log::debug!("p: client_config = {:?}", client_config);
 
         client_config
     }

--- a/packages/talos_suffix/src/core.rs
+++ b/packages/talos_suffix/src/core.rs
@@ -56,6 +56,8 @@ pub type SuffixItemType<T> = T;
 
 pub trait SuffixTrait<T> {
     fn get(&self, version: u64) -> SuffixResult<Option<SuffixItem<T>>>;
+    fn get_mut(&mut self, version: u64) -> Option<&mut SuffixItem<T>>;
+    fn get_meta(&self) -> &SuffixMeta;
     fn insert(&mut self, version: u64, message: SuffixItemType<T>) -> SuffixResult<()>;
     fn update_decision(&mut self, version: u64, decision_ver: u64) -> SuffixResult<()>;
     fn prune_till_index(&mut self, index: usize) -> SuffixResult<Vec<Option<SuffixItem<T>>>>;

--- a/packages/talos_suffix/src/suffix.rs
+++ b/packages/talos_suffix/src/suffix.rs
@@ -124,8 +124,9 @@ where
     pub fn retrieve_all_some_vec_items(&self) -> Vec<(usize, u64, Option<u64>)> {
         self.messages
             .iter()
+            .flatten()
             .enumerate()
-            .filter_map(|(i, x)| x.is_some().then(|| (i, x.as_ref().unwrap().item_ver, x.as_ref().unwrap().decision_ver)))
+            .map(|(i, x)| (i, x.item_ver, x.decision_ver))
             .collect()
     }
 

--- a/packages/talos_suffix/src/suffix.rs
+++ b/packages/talos_suffix/src/suffix.rs
@@ -228,8 +228,17 @@ where
         Ok(suffix_item)
     }
 
+    fn get_mut(&mut self, version: u64) -> Option<&mut SuffixItem<T>> {
+        let index = self.index_from_head(version)?;
+        self.messages.get_mut(index)?.as_mut()
+    }
+
+    fn get_meta(&self) -> &SuffixMeta {
+        &self.meta
+    }
+
     fn insert(&mut self, version: u64, message: T) -> SuffixResult<()> {
-        // // The very first item inserted on the suffix will automatically be made head of the suffix.
+        // The very first item inserted on the suffix will automatically be made head of the suffix.
         if self.meta.head == 0 {
             self.update_head(version);
         }
@@ -254,12 +263,6 @@ where
 
             self.meta.last_insert_vers = version;
         }
-
-        // info!(
-        //     "All some items on suffix insert where head ={}.... {:?}",
-        //     self.meta.head,
-        //     self.retrieve_all_some_vec_items()
-        // );
 
         Ok(())
     }


### PR DESCRIPTION
- Some refactors and renames
- Change how whitelist of actions are fed to the messenger service
- Move messenger suffix related `get_mut` and `get_meta` to the core suffix.
- Handle how actions failed to process will be marked in the suffix