### PR TITLE
feat: allow headers pass through

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2539,6 +2539,7 @@ dependencies = [
 name = "talos_certifier_adapters"
 version = "0.0.1"
 dependencies = [
+ "ahash 0.8.3",
  "async-trait",
  "deadpool-postgres",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,5 @@
 [workspace]
 resolver = "2"
-
 members = [
     "packages/*",
     #  Example crates

--- a/examples/messenger_using_kafka/src/kafka_producer.rs
+++ b/examples/messenger_using_kafka/src/kafka_producer.rs
@@ -1,13 +1,9 @@
+use ahash::HashMap;
 use async_trait::async_trait;
 use log::info;
 use rdkafka::producer::ProducerContext;
 use talos_messenger_actions::kafka::{context::MessengerProducerDeliveryOpaque, models::KafkaAction, producer::KafkaProducer};
 use talos_messenger_core::core::{MessengerPublisher, PublishActionType};
-// use talos_messenger::{
-//     core::{MessengerPublisher, PublishActionType},
-//     kafka::producer::{KafkaProducer, MessengerProducerDeliveryOpaque},
-//     models::commit_actions::publish::KafkaAction,
-// };
 
 pub struct MessengerKafkaPublisher<C: ProducerContext + 'static> {
     pub publisher: KafkaProducer<C>,
@@ -24,7 +20,7 @@ where
         PublishActionType::Kafka
     }
 
-    async fn send(&self, version: u64, payload: Self::Payload, additional_data: Self::AdditionalData) -> () {
+    async fn send(&self, version: u64, payload: Self::Payload, headers: HashMap<String, String>, additional_data: Self::AdditionalData) -> () {
         info!("[MessengerKafkaPublisher] Publishing message with payload=\n{payload:#?}");
 
         let mut bytes: Vec<u8> = Vec::new();
@@ -44,7 +40,7 @@ where
                 payload.partition,
                 payload.key.as_deref(),
                 payload_str,
-                None,
+                headers,
                 Box::new(delivery_opaque),
             )
             .unwrap();

--- a/packages/talos_certifier/src/core.rs
+++ b/packages/talos_certifier/src/core.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use async_trait::async_trait;
 use strum::{Display, EnumString};
 use tokio::sync::broadcast;
@@ -7,13 +9,30 @@ use crate::{
     model::{CandidateMessage, DecisionMessage},
 };
 
-type Version = u64;
+#[derive(Debug, Clone)]
+pub struct ChannelMeta {
+    pub headers: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CandidateChannelMessage {
+    pub message: CandidateMessage,
+    pub meta: ChannelMeta,
+}
+
+#[derive(Debug, Clone)]
+pub struct DecisionChannelMessage {
+    pub decision_version: u64,
+    pub message: DecisionMessage,
+    pub meta: ChannelMeta,
+}
+
 #[derive(Debug, Clone)]
 // TODO: double check this setting
 #[allow(clippy::large_enum_variant)]
 pub enum ChannelMessage {
-    Candidate(CandidateMessage),
-    Decision(Version, DecisionMessage),
+    Candidate(Box<CandidateChannelMessage>),
+    Decision(Box<DecisionChannelMessage>),
 }
 
 #[derive(Debug, Display, Eq, PartialEq, EnumString)]
@@ -34,8 +53,13 @@ pub enum SystemMessage {
 pub type ServiceResult<T = ()> = Result<T, Box<SystemServiceError>>;
 
 #[derive(Debug)]
-pub enum DecisionOutboxChannelMessage {
-    Decision(DecisionMessage),
+pub struct DecisionOutboxChannelMessageMeta {
+    pub headers: HashMap<String, String>,
+}
+#[derive(Debug)]
+pub struct DecisionOutboxChannelMessage {
+    pub message: DecisionMessage,
+    pub meta: DecisionOutboxChannelMessageMeta,
 }
 
 #[derive(Debug, Clone)]

--- a/packages/talos_certifier/src/core.rs
+++ b/packages/talos_certifier/src/core.rs
@@ -1,5 +1,4 @@
-use std::collections::HashMap;
-
+use ahash::HashMap;
 use async_trait::async_trait;
 use strum::{Display, EnumString};
 use tokio::sync::broadcast;
@@ -10,26 +9,19 @@ use crate::{
 };
 
 #[derive(Debug, Clone)]
-pub struct ChannelMeta {
-    pub headers: HashMap<String, String>,
-}
-
-#[derive(Debug, Clone)]
 pub struct CandidateChannelMessage {
     pub message: CandidateMessage,
-    pub meta: ChannelMeta,
+    pub headers: HashMap<String, String>,
 }
 
 #[derive(Debug, Clone)]
 pub struct DecisionChannelMessage {
     pub decision_version: u64,
     pub message: DecisionMessage,
-    pub meta: ChannelMeta,
+    pub headers: HashMap<String, String>,
 }
 
 #[derive(Debug, Clone)]
-// TODO: double check this setting
-#[allow(clippy::large_enum_variant)]
 pub enum ChannelMessage {
     Candidate(Box<CandidateChannelMessage>),
     Decision(Box<DecisionChannelMessage>),
@@ -53,13 +45,9 @@ pub enum SystemMessage {
 pub type ServiceResult<T = ()> = Result<T, Box<SystemServiceError>>;
 
 #[derive(Debug)]
-pub struct DecisionOutboxChannelMessageMeta {
-    pub headers: HashMap<String, String>,
-}
-#[derive(Debug)]
 pub struct DecisionOutboxChannelMessage {
     pub message: DecisionMessage,
-    pub meta: DecisionOutboxChannelMessageMeta,
+    pub headers: HashMap<String, String>,
 }
 
 #[derive(Debug, Clone)]

--- a/packages/talos_certifier/src/lib.rs
+++ b/packages/talos_certifier/src/lib.rs
@@ -8,6 +8,6 @@ pub mod ports;
 pub mod services;
 pub mod talos_certifier_service;
 
-pub use crate::core::{ChannelMessage, ChannelMeta, SystemMessage};
+pub use crate::core::{ChannelMessage, SystemMessage};
 pub use certifier::Certifier;
 pub use certifier::CertifierCandidate;

--- a/packages/talos_certifier/src/lib.rs
+++ b/packages/talos_certifier/src/lib.rs
@@ -8,6 +8,6 @@ pub mod ports;
 pub mod services;
 pub mod talos_certifier_service;
 
-pub use crate::core::{ChannelMessage, SystemMessage};
+pub use crate::core::{ChannelMessage, ChannelMeta, SystemMessage};
 pub use certifier::Certifier;
 pub use certifier::CertifierCandidate;

--- a/packages/talos_certifier/src/ports/message.rs
+++ b/packages/talos_certifier/src/ports/message.rs
@@ -1,5 +1,5 @@
+use ahash::HashMap;
 use async_trait::async_trait;
-use std::collections::HashMap;
 use tokio::task::JoinHandle;
 
 use crate::errors::SystemServiceError;
@@ -24,5 +24,5 @@ pub trait MessageReciever: SharedPortTraits {
 // The trait that should be implemented by any adapter that will publish the Decision message from Certifier Domain.
 #[async_trait]
 pub trait MessagePublisher: SharedPortTraits {
-    async fn publish_message(&self, key: &str, value: &str, headers: Option<HashMap<String, String>>) -> Result<(), SystemServiceError>;
+    async fn publish_message(&self, key: &str, value: &str, headers: HashMap<String, String>) -> Result<(), SystemServiceError>;
 }

--- a/packages/talos_certifier/src/services/certifier_service.rs
+++ b/packages/talos_certifier/src/services/certifier_service.rs
@@ -9,7 +9,6 @@ use time::OffsetDateTime;
 use tokio::sync::mpsc;
 
 use crate::certifier::utils::generate_certifier_sets_from_suffix;
-use crate::core::DecisionOutboxChannelMessageMeta;
 use crate::{
     core::{DecisionOutboxChannelMessage, ServiceResult, System, SystemService},
     errors::{CertificationError, SystemErrorType, SystemServiceError, SystemServiceErrorKind},
@@ -153,9 +152,7 @@ impl CertifierService {
 
                 let decision_outbox_channel_message = DecisionOutboxChannelMessage {
                     message: decision_message.clone(),
-                    meta: DecisionOutboxChannelMessageMeta {
-                        headers: candidate.meta.headers.clone(),
-                    },
+                    headers: candidate.headers.clone(),
                 };
 
                 Ok(self

--- a/packages/talos_certifier/src/services/certifier_service.rs
+++ b/packages/talos_certifier/src/services/certifier_service.rs
@@ -5,6 +5,7 @@ use async_trait::async_trait;
 use log::{debug, error, warn};
 use talos_suffix::core::SuffixConfig;
 use talos_suffix::{get_nonempty_suffix_items, Suffix, SuffixTrait};
+use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 use tokio::sync::mpsc;
 
@@ -150,9 +151,14 @@ impl CertifierService {
             Some(ChannelMessage::Candidate(candidate)) => {
                 let decision_message = self.process_candidate(&candidate.message)?;
 
+                let mut headers = candidate.headers.clone();
+                if let Ok(cert_time) = OffsetDateTime::now_utc().format(&Rfc3339) {
+                    headers.insert("certTime".to_owned(), cert_time);
+                }
+
                 let decision_outbox_channel_message = DecisionOutboxChannelMessage {
                     message: decision_message.clone(),
-                    headers: candidate.headers.clone(),
+                    headers,
                 };
 
                 Ok(self

--- a/packages/talos_certifier/src/services/certifier_service.rs
+++ b/packages/talos_certifier/src/services/certifier_service.rs
@@ -9,6 +9,7 @@ use time::OffsetDateTime;
 use tokio::sync::mpsc;
 
 use crate::certifier::utils::generate_certifier_sets_from_suffix;
+use crate::core::DecisionOutboxChannelMessageMeta;
 use crate::{
     core::{DecisionOutboxChannelMessage, ServiceResult, System, SystemService},
     errors::{CertificationError, SystemErrorType, SystemServiceError, SystemServiceErrorKind},
@@ -89,7 +90,7 @@ impl CertifierService {
         Ok(dm)
     }
 
-    pub(crate) fn process_decision(&mut self, decision_version: &u64, decision_message: &DecisionMessage) -> Result<(), CertificationError> {
+    pub(crate) fn process_decision(&mut self, decision_version: u64, decision_message: &DecisionMessage) -> Result<(), CertificationError> {
         // update the decision in suffix
         debug!(
             "[Process Decision message] Version {} and Decision Message {:?} ",
@@ -111,7 +112,7 @@ impl CertifierService {
 
         if candidate_version_index.is_some() && candidate_version_index.unwrap().le(&self.suffix.messages.len()) {
             self.suffix
-                .update_decision_suffix_item(candidate_version, *decision_version)
+                .update_decision_suffix_item(candidate_version, decision_version)
                 .map_err(CertificationError::SuffixError)?;
 
             // check if all prioir items are decided.
@@ -147,12 +148,19 @@ impl CertifierService {
 
     pub async fn process_message(&mut self, channel_message: &Option<ChannelMessage>) -> ServiceResult {
         if let Err(certification_error) = match channel_message {
-            Some(ChannelMessage::Candidate(message)) => {
-                let decision_message = self.process_candidate(message)?;
+            Some(ChannelMessage::Candidate(candidate)) => {
+                let decision_message = self.process_candidate(&candidate.message)?;
+
+                let decision_outbox_channel_message = DecisionOutboxChannelMessage {
+                    message: decision_message.clone(),
+                    meta: DecisionOutboxChannelMessageMeta {
+                        headers: candidate.meta.headers.clone(),
+                    },
+                };
 
                 Ok(self
                     .decision_outbox_tx
-                    .send(DecisionOutboxChannelMessage::Decision(decision_message.clone()))
+                    .send(decision_outbox_channel_message)
                     .await
                     .map_err(|e| SystemServiceError {
                         kind: SystemServiceErrorKind::SystemError(SystemErrorType::Channel),
@@ -162,7 +170,7 @@ impl CertifierService {
                     })?)
             }
 
-            Some(ChannelMessage::Decision(version, decision_message)) => self.process_decision(version, decision_message),
+            Some(ChannelMessage::Decision(decision)) => self.process_decision(decision.decision_version, &decision.message),
 
             None => Ok(()),
             // _ => (),

--- a/packages/talos_certifier/src/services/decision_outbox_service.rs
+++ b/packages/talos_certifier/src/services/decision_outbox_service.rs
@@ -95,7 +95,6 @@ impl DecisionOutboxService {
             decision_publish_header.insert("certSafepoint".to_string(), safepoint.to_string());
         }
         decision_publish_header.insert("certAgent".to_string(), decision_message.agent.to_owned());
-        // decision_publish_header.insert("certTime".to_string(), decision_message.safepoint.to_owned());
 
         debug!("Publishing message {}", decision_message.version);
         publisher

--- a/packages/talos_certifier/src/services/tests/certifier_service.rs
+++ b/packages/talos_certifier/src/services/tests/certifier_service.rs
@@ -1,6 +1,10 @@
-use std::sync::{atomic::AtomicI64, Arc};
+use std::{
+    collections::HashMap,
+    sync::{atomic::AtomicI64, Arc},
+};
 
 use crate::{
+    core::{CandidateChannelMessage, DecisionChannelMessage},
     errors::{SystemErrorType, SystemServiceErrorKind},
     model::{
         CandidateMessage, {Decision, DecisionMessage},
@@ -18,7 +22,16 @@ use crate::{
 
 async fn send_candidate_message(message_channel_tx: mpsc::Sender<ChannelMessage>, candidate_message: CandidateMessage) {
     tokio::spawn(async move {
-        message_channel_tx.send(ChannelMessage::Candidate(candidate_message)).await.unwrap();
+        message_channel_tx
+            .send(ChannelMessage::Candidate(
+                CandidateChannelMessage {
+                    message: candidate_message,
+                    meta: crate::ChannelMeta { headers: HashMap::new() },
+                }
+                .into(),
+            ))
+            .await
+            .unwrap();
     });
 }
 
@@ -99,14 +112,14 @@ async fn test_certification_rule_2() {
     assert!(result.is_ok());
 
     // Rule 1
-    if let Some(DecisionOutboxChannelMessage::Decision(decision)) = do_channel_rx.recv().await {
-        assert!(decision.conflict_version.is_none());
-        assert_eq!(decision.decision, Decision::Committed);
+    if let Some(decision) = do_channel_rx.recv().await {
+        assert!(decision.message.conflict_version.is_none());
+        assert_eq!(decision.message.decision, Decision::Committed);
     };
     // Rule 2
-    if let Some(DecisionOutboxChannelMessage::Decision(decision)) = do_channel_rx.recv().await {
-        assert!(decision.conflict_version.is_none());
-        assert_eq!(decision.decision, Decision::Aborted);
+    if let Some(decision) = do_channel_rx.recv().await {
+        assert!(decision.message.conflict_version.is_none());
+        assert_eq!(decision.message.decision, Decision::Aborted);
     };
 }
 
@@ -204,9 +217,19 @@ async fn test_certification_process_decision() {
 
     assert!(result.is_ok());
 
-    if let Some(DecisionOutboxChannelMessage::Decision(decision)) = do_channel_rx.recv().await {
+    if let Some(decision) = do_channel_rx.recv().await {
         tokio::spawn(async move {
-            message_channel_tx.send(ChannelMessage::Decision(decision.version, decision)).await.unwrap();
+            message_channel_tx
+                .send(ChannelMessage::Decision(
+                    DecisionChannelMessage {
+                        decision_version: decision.message.version,
+                        message: decision.message,
+                        meta: crate::ChannelMeta { headers: HashMap::new() },
+                    }
+                    .into(),
+                ))
+                .await
+                .unwrap();
         });
     };
 
@@ -262,10 +285,20 @@ async fn test_certification_process_decision_incorrect_version() {
     assert!(result.is_ok());
 
     // pass incorrect decision (version incorrect), will not do anything as item is not found on suffix.
-    if let Some(DecisionOutboxChannelMessage::Decision(decision)) = do_channel_rx.recv().await {
+    if let Some(decision) = do_channel_rx.recv().await {
         tokio::spawn(async move {
             message_channel_tx
-                .send(ChannelMessage::Decision(12, DecisionMessage { version: 10, ..decision }))
+                .send(ChannelMessage::Decision(
+                    DecisionChannelMessage {
+                        decision_version: 12,
+                        message: DecisionMessage {
+                            version: 10,
+                            ..decision.message
+                        },
+                        meta: crate::ChannelMeta { headers: HashMap::new() },
+                    }
+                    .into(),
+                ))
                 .await
                 .unwrap();
         });
@@ -423,50 +456,71 @@ async fn test_certification_check_suffix_prune_is_ready_threshold_30pc() {
     let result = certifier_svc.run().await;
     assert!(result.is_ok());
 
-    if let Some(DecisionOutboxChannelMessage::Decision(decision)) = do_channel_rx.recv().await {
+    if let Some(decision) = do_channel_rx.recv().await {
         tokio::spawn({
             let message_channel_tx_clone = message_channel_tx.clone();
             async move {
-                message_channel_tx_clone
-                    .send(ChannelMessage::Decision(6, DecisionMessage { ..decision }))
-                    .await
-                    .unwrap();
+                let _ = message_channel_tx_clone
+                    .send(ChannelMessage::Decision(
+                        DecisionChannelMessage {
+                            decision_version: 6,
+                            message: decision.message,
+                            meta: crate::ChannelMeta { headers: HashMap::new() },
+                        }
+                        .into(),
+                    ))
+                    .await;
             }
         });
     };
-    if let Some(DecisionOutboxChannelMessage::Decision(decision)) = do_channel_rx.recv().await {
+    if let Some(decision) = do_channel_rx.recv().await {
         tokio::spawn({
             let message_channel_tx_clone = message_channel_tx.clone();
-
             async move {
-                message_channel_tx_clone
-                    .send(ChannelMessage::Decision(7, DecisionMessage { ..decision }))
-                    .await
-                    .unwrap();
+                let _ = message_channel_tx_clone
+                    .send(ChannelMessage::Decision(
+                        DecisionChannelMessage {
+                            decision_version: 7,
+                            message: decision.message,
+                            meta: crate::ChannelMeta { headers: HashMap::new() },
+                        }
+                        .into(),
+                    ))
+                    .await;
             }
         });
     };
-    if let Some(DecisionOutboxChannelMessage::Decision(decision)) = do_channel_rx.recv().await {
+    if let Some(decision) = do_channel_rx.recv().await {
         tokio::spawn({
             let message_channel_tx_clone = message_channel_tx.clone();
-
             async move {
-                message_channel_tx_clone
-                    .send(ChannelMessage::Decision(8, DecisionMessage { ..decision }))
-                    .await
-                    .unwrap();
+                let _ = message_channel_tx_clone
+                    .send(ChannelMessage::Decision(
+                        DecisionChannelMessage {
+                            decision_version: 8,
+                            message: decision.message,
+                            meta: crate::ChannelMeta { headers: HashMap::new() },
+                        }
+                        .into(),
+                    ))
+                    .await;
             }
         });
     };
-    if let Some(DecisionOutboxChannelMessage::Decision(decision)) = do_channel_rx.recv().await {
+    if let Some(decision) = do_channel_rx.recv().await {
         tokio::spawn({
             let message_channel_tx_clone = message_channel_tx.clone();
-
             async move {
-                message_channel_tx_clone
-                    .send(ChannelMessage::Decision(10, DecisionMessage { ..decision }))
-                    .await
-                    .unwrap();
+                let _ = message_channel_tx_clone
+                    .send(ChannelMessage::Decision(
+                        DecisionChannelMessage {
+                            decision_version: 10,
+                            message: decision.message,
+                            meta: crate::ChannelMeta { headers: HashMap::new() },
+                        }
+                        .into(),
+                    ))
+                    .await;
             }
         });
     };
@@ -563,26 +617,37 @@ async fn test_certification_check_suffix_prune_is_not_at_threshold() {
     let result = certifier_svc.run().await;
     assert!(result.is_ok());
 
-    if let Some(DecisionOutboxChannelMessage::Decision(decision)) = do_channel_rx.recv().await {
+    if let Some(decision) = do_channel_rx.recv().await {
         tokio::spawn({
             let message_channel_tx_clone = message_channel_tx.clone();
             async move {
-                message_channel_tx_clone
-                    .send(ChannelMessage::Decision(6, DecisionMessage { ..decision }))
-                    .await
-                    .unwrap();
+                let _ = message_channel_tx_clone
+                    .send(ChannelMessage::Decision(
+                        DecisionChannelMessage {
+                            decision_version: 6,
+                            message: decision.message,
+                            meta: crate::ChannelMeta { headers: HashMap::new() },
+                        }
+                        .into(),
+                    ))
+                    .await;
             }
         });
     };
-    if let Some(DecisionOutboxChannelMessage::Decision(decision)) = do_channel_rx.recv().await {
+    if let Some(decision) = do_channel_rx.recv().await {
         tokio::spawn({
             let message_channel_tx_clone = message_channel_tx.clone();
-
             async move {
-                message_channel_tx_clone
-                    .send(ChannelMessage::Decision(7, DecisionMessage { ..decision }))
-                    .await
-                    .unwrap();
+                let _ = message_channel_tx_clone
+                    .send(ChannelMessage::Decision(
+                        DecisionChannelMessage {
+                            decision_version: 7,
+                            message: decision.message,
+                            meta: crate::ChannelMeta { headers: HashMap::new() },
+                        }
+                        .into(),
+                    ))
+                    .await;
             }
         });
     };

--- a/packages/talos_certifier/src/services/tests/certifier_service.rs
+++ b/packages/talos_certifier/src/services/tests/certifier_service.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::HashMap,
-    sync::{atomic::AtomicI64, Arc},
-};
+use std::sync::{atomic::AtomicI64, Arc};
 
 use crate::{
     core::{CandidateChannelMessage, DecisionChannelMessage},
@@ -12,6 +9,7 @@ use crate::{
     services::CertifierServiceConfig,
     ChannelMessage, SystemMessage,
 };
+use ahash::{HashMap, HashMapExt};
 use talos_suffix::core::SuffixConfig;
 use tokio::sync::{broadcast, mpsc};
 
@@ -26,7 +24,7 @@ async fn send_candidate_message(message_channel_tx: mpsc::Sender<ChannelMessage>
             .send(ChannelMessage::Candidate(
                 CandidateChannelMessage {
                     message: candidate_message,
-                    meta: crate::ChannelMeta { headers: HashMap::new() },
+                    headers: HashMap::new(),
                 }
                 .into(),
             ))
@@ -224,7 +222,7 @@ async fn test_certification_process_decision() {
                     DecisionChannelMessage {
                         decision_version: decision.message.version,
                         message: decision.message,
-                        meta: crate::ChannelMeta { headers: HashMap::new() },
+                        headers: HashMap::new(),
                     }
                     .into(),
                 ))
@@ -295,7 +293,7 @@ async fn test_certification_process_decision_incorrect_version() {
                             version: 10,
                             ..decision.message
                         },
-                        meta: crate::ChannelMeta { headers: HashMap::new() },
+                        headers: HashMap::new(),
                     }
                     .into(),
                 ))
@@ -465,7 +463,7 @@ async fn test_certification_check_suffix_prune_is_ready_threshold_30pc() {
                         DecisionChannelMessage {
                             decision_version: 6,
                             message: decision.message,
-                            meta: crate::ChannelMeta { headers: HashMap::new() },
+                            headers: HashMap::new(),
                         }
                         .into(),
                     ))
@@ -482,7 +480,7 @@ async fn test_certification_check_suffix_prune_is_ready_threshold_30pc() {
                         DecisionChannelMessage {
                             decision_version: 7,
                             message: decision.message,
-                            meta: crate::ChannelMeta { headers: HashMap::new() },
+                            headers: HashMap::new(),
                         }
                         .into(),
                     ))
@@ -499,7 +497,7 @@ async fn test_certification_check_suffix_prune_is_ready_threshold_30pc() {
                         DecisionChannelMessage {
                             decision_version: 8,
                             message: decision.message,
-                            meta: crate::ChannelMeta { headers: HashMap::new() },
+                            headers: HashMap::new(),
                         }
                         .into(),
                     ))
@@ -516,7 +514,7 @@ async fn test_certification_check_suffix_prune_is_ready_threshold_30pc() {
                         DecisionChannelMessage {
                             decision_version: 10,
                             message: decision.message,
-                            meta: crate::ChannelMeta { headers: HashMap::new() },
+                            headers: HashMap::new(),
                         }
                         .into(),
                     ))
@@ -626,7 +624,7 @@ async fn test_certification_check_suffix_prune_is_not_at_threshold() {
                         DecisionChannelMessage {
                             decision_version: 6,
                             message: decision.message,
-                            meta: crate::ChannelMeta { headers: HashMap::new() },
+                            headers: HashMap::new(),
                         }
                         .into(),
                     ))
@@ -643,7 +641,7 @@ async fn test_certification_check_suffix_prune_is_not_at_threshold() {
                         DecisionChannelMessage {
                             decision_version: 7,
                             message: decision.message,
-                            meta: crate::ChannelMeta { headers: HashMap::new() },
+                            headers: HashMap::new(),
                         }
                         .into(),
                     ))

--- a/packages/talos_certifier/src/services/tests/decision_outbox_service.rs
+++ b/packages/talos_certifier/src/services/tests/decision_outbox_service.rs
@@ -111,18 +111,21 @@ async fn test_candidate_message_create_decision_message() {
     // sending a decision into decision outbox service
     tokio::spawn(async move {
         do_channel_tx_clone
-            .send(crate::core::DecisionOutboxChannelMessage::Decision(DecisionMessage {
-                xid: "test-xid-1".to_owned(),
-                agent: "test-agent-1".to_owned(),
-                cohort: "test-cohort-1".to_owned(),
-                decision: Decision::Committed,
-                suffix_start: 2,
-                version: 4,
-                duplicate_version: None,
-                safepoint: Some(3),
-                conflict_version: None,
-                metrics: TxProcessingTimeline::default(),
-            }))
+            .send(crate::core::DecisionOutboxChannelMessage {
+                message: DecisionMessage {
+                    xid: "test-xid-1".to_owned(),
+                    agent: "test-agent-1".to_owned(),
+                    cohort: "test-cohort-1".to_owned(),
+                    decision: Decision::Committed,
+                    suffix_start: 2,
+                    version: 4,
+                    duplicate_version: None,
+                    safepoint: Some(3),
+                    conflict_version: None,
+                    metrics: TxProcessingTimeline::default(),
+                },
+                meta: crate::core::DecisionOutboxChannelMessageMeta { headers: HashMap::new() },
+            })
             .await
             .unwrap();
     });
@@ -170,36 +173,42 @@ async fn test_save_and_publish_multiple_decisions() {
     // sending a decision into decision outbox service
     tokio::spawn(async move {
         do_channel_tx_clone
-            .send(crate::core::DecisionOutboxChannelMessage::Decision(DecisionMessage {
-                xid: "test-xid-1".to_owned(),
-                agent: "test-agent-1".to_owned(),
-                cohort: "test-cohort-1".to_owned(),
-                decision: Decision::Committed,
-                suffix_start: 2,
-                version: 4,
-                duplicate_version: None,
-                safepoint: Some(3),
-                conflict_version: None,
-                metrics: TxProcessingTimeline::default(),
-            }))
+            .send(crate::core::DecisionOutboxChannelMessage {
+                message: DecisionMessage {
+                    xid: "test-xid-1".to_owned(),
+                    agent: "test-agent-1".to_owned(),
+                    cohort: "test-cohort-1".to_owned(),
+                    decision: Decision::Committed,
+                    suffix_start: 2,
+                    version: 4,
+                    duplicate_version: None,
+                    safepoint: Some(3),
+                    conflict_version: None,
+                    metrics: TxProcessingTimeline::default(),
+                },
+                meta: crate::core::DecisionOutboxChannelMessageMeta { headers: HashMap::new() },
+            })
             .await
             .unwrap();
     });
 
     tokio::spawn(async move {
         do_channel_tx_clone_2
-            .send(crate::core::DecisionOutboxChannelMessage::Decision(DecisionMessage {
-                xid: "test-xid-2".to_owned(),
-                agent: "test-agent-1".to_owned(),
-                cohort: "test-cohort-1".to_owned(),
-                decision: Decision::Committed,
-                suffix_start: 2,
-                version: 4,
-                duplicate_version: None,
-                safepoint: Some(3),
-                conflict_version: None,
-                metrics: TxProcessingTimeline::default(),
-            }))
+            .send(crate::core::DecisionOutboxChannelMessage {
+                message: DecisionMessage {
+                    xid: "test-xid-2".to_owned(),
+                    agent: "test-agent-1".to_owned(),
+                    cohort: "test-cohort-1".to_owned(),
+                    decision: Decision::Committed,
+                    suffix_start: 2,
+                    version: 4,
+                    duplicate_version: None,
+                    safepoint: Some(3),
+                    conflict_version: None,
+                    metrics: TxProcessingTimeline::default(),
+                },
+                meta: crate::core::DecisionOutboxChannelMessageMeta { headers: HashMap::new() },
+            })
             .await
             .unwrap();
     });
@@ -284,18 +293,21 @@ async fn test_capture_child_thread_dberror() {
     // sending a decision into decision outbox service
     tokio::spawn(async move {
         do_channel_tx_clone
-            .send(crate::core::DecisionOutboxChannelMessage::Decision(DecisionMessage {
-                xid: "test-xid-1".to_owned(),
-                agent: "test-agent-1".to_owned(),
-                cohort: "test-cohort-1".to_owned(),
-                decision: Decision::Committed,
-                suffix_start: 2,
-                version: 4,
-                duplicate_version: None,
-                safepoint: Some(3),
-                conflict_version: None,
-                metrics: TxProcessingTimeline::default(),
-            }))
+            .send(crate::core::DecisionOutboxChannelMessage {
+                message: DecisionMessage {
+                    xid: "test-xid-1".to_owned(),
+                    agent: "test-agent-1".to_owned(),
+                    cohort: "test-cohort-1".to_owned(),
+                    decision: Decision::Committed,
+                    suffix_start: 2,
+                    version: 4,
+                    duplicate_version: None,
+                    safepoint: Some(3),
+                    conflict_version: None,
+                    metrics: TxProcessingTimeline::default(),
+                },
+                meta: crate::core::DecisionOutboxChannelMessageMeta { headers: HashMap::new() },
+            })
             .await
             .unwrap();
     });
@@ -349,7 +361,13 @@ async fn test_capture_publish_error() {
         metrics: TxProcessingTimeline::default(),
     };
 
-    if let Err(publish_error) = DecisionOutboxService::publish_decision(&Arc::new(Box::new(mock_decision_publisher)), &decision_message).await {
+    if let Err(publish_error) = DecisionOutboxService::publish_decision(
+        &Arc::new(Box::new(mock_decision_publisher)),
+        &decision_message,
+        crate::core::DecisionOutboxChannelMessageMeta { headers: HashMap::new() },
+    )
+    .await
+    {
         assert!(publish_error.kind == SystemServiceErrorKind::MessagePublishError);
     }
 }

--- a/packages/talos_certifier/src/services/tests/message_receiver_service.rs
+++ b/packages/talos_certifier/src/services/tests/message_receiver_service.rs
@@ -1,8 +1,6 @@
-use std::{
-    collections::HashMap,
-    sync::{atomic::AtomicI64, Arc},
-};
+use std::sync::{atomic::AtomicI64, Arc};
 
+use ahash::{HashMap, HashMapExt};
 use async_trait::async_trait;
 use tokio::{
     sync::{broadcast, mpsc},
@@ -111,7 +109,7 @@ async fn test_consume_message() {
         .send(ChannelMessage::Candidate(
             CandidateChannelMessage {
                 message: candidate_message,
-                meta: crate::ChannelMeta { headers: HashMap::new() },
+                headers: HashMap::new(),
             }
             .into(),
         ))
@@ -166,7 +164,7 @@ async fn test_consume_message_error() {
         .send(ChannelMessage::Candidate(
             CandidateChannelMessage {
                 message: candidate_message,
-                meta: crate::ChannelMeta { headers: HashMap::new() },
+                headers: HashMap::new(),
             }
             .into(),
         ))

--- a/packages/talos_certifier/src/services/tests/message_receiver_service.rs
+++ b/packages/talos_certifier/src/services/tests/message_receiver_service.rs
@@ -1,4 +1,7 @@
-use std::sync::{atomic::AtomicI64, Arc};
+use std::{
+    collections::HashMap,
+    sync::{atomic::AtomicI64, Arc},
+};
 
 use async_trait::async_trait;
 use tokio::{
@@ -7,7 +10,7 @@ use tokio::{
 };
 
 use crate::{
-    core::{System, SystemService},
+    core::{CandidateChannelMessage, System, SystemService},
     errors::SystemServiceError,
     model::CandidateMessage,
     ports::{common::SharedPortTraits, errors::MessageReceiverError, MessageReciever},
@@ -28,8 +31,8 @@ impl MessageReciever for MockReciever {
         let msg = self.consumer.recv().await.unwrap();
 
         let vers = match &msg {
-            ChannelMessage::Candidate(msg) => Some(msg.version),
-            ChannelMessage::Decision(vers, _) => Some(vers).copied(),
+            ChannelMessage::Candidate(msg) => Some(msg.message.version),
+            ChannelMessage::Decision(decision) => Some(decision.decision_version),
         };
 
         self.offset = vers;
@@ -88,22 +91,30 @@ async fn test_consume_message() {
 
     let mut msg_receiver = MessageReceiverService::new(Box::new(mock_receiver), msg_channel_tx, commit_offset, system);
 
+    let candidate_message = CandidateMessage {
+        xid: "xid-1".to_string(),
+        version: 8,
+        agent: "agent-1".to_string(),
+        cohort: "cohort-1".to_string(),
+        snapshot: 5,
+        readvers: vec![],
+        readset: vec![],
+        writeset: vec!["ksp:w1".to_owned()],
+        metadata: None,
+        on_commit: None,
+        statemap: None,
+        published_at: 0,
+        received_at: 0,
+    };
+
     mock_channel_tx
-        .send(ChannelMessage::Candidate(CandidateMessage {
-            xid: "xid-1".to_string(),
-            version: 8,
-            agent: "agent-1".to_string(),
-            cohort: "cohort-1".to_string(),
-            snapshot: 5,
-            readvers: vec![],
-            readset: vec![],
-            writeset: vec!["ksp:w1".to_owned()],
-            metadata: None,
-            on_commit: None,
-            statemap: None,
-            published_at: 0,
-            received_at: 0,
-        }))
+        .send(ChannelMessage::Candidate(
+            CandidateChannelMessage {
+                message: candidate_message,
+                meta: crate::ChannelMeta { headers: HashMap::new() },
+            }
+            .into(),
+        ))
         .await
         .unwrap();
 
@@ -111,9 +122,9 @@ async fn test_consume_message() {
 
     assert!(result.is_ok());
 
-    if let Some(ChannelMessage::Candidate(msg)) = msg_channel_rx.recv().await {
-        assert_eq!(msg.version, 8);
-        assert_eq!(msg.xid, "xid-1".to_string());
+    if let Some(ChannelMessage::Candidate(candidate)) = msg_channel_rx.recv().await {
+        assert_eq!(candidate.message.version, 8);
+        assert_eq!(candidate.message.xid, "xid-1".to_string());
     }
 }
 
@@ -136,23 +147,29 @@ async fn test_consume_message_error() {
     let commit_offset: Arc<AtomicI64> = Arc::new(0.into());
 
     let mut msg_receiver = MessageReceiverService::new(Box::new(mock_receiver), msg_channel_tx, commit_offset, system);
-
+    let candidate_message = CandidateMessage {
+        xid: "xid-1".to_string(),
+        version: 8,
+        agent: "agent-1".to_string(),
+        cohort: "cohort-1".to_string(),
+        snapshot: 5,
+        readvers: vec![],
+        readset: vec![],
+        writeset: vec!["ksp:w1".to_owned()],
+        metadata: None,
+        on_commit: None,
+        statemap: None,
+        published_at: 0,
+        received_at: 0,
+    };
     mock_channel_tx
-        .send(ChannelMessage::Candidate(CandidateMessage {
-            xid: "xid-1".to_string(),
-            version: 8,
-            agent: "agent-1".to_string(),
-            cohort: "cohort-1".to_string(),
-            snapshot: 5,
-            readvers: vec![],
-            readset: vec![],
-            writeset: vec!["ksp:w1".to_owned()],
-            metadata: None,
-            on_commit: None,
-            statemap: None,
-            published_at: 0,
-            received_at: 0,
-        }))
+        .send(ChannelMessage::Candidate(
+            CandidateChannelMessage {
+                message: candidate_message,
+                meta: crate::ChannelMeta { headers: HashMap::new() },
+            }
+            .into(),
+        ))
         .await
         .unwrap();
 

--- a/packages/talos_certifier_adapters/Cargo.toml
+++ b/packages/talos_certifier_adapters/Cargo.toml
@@ -26,6 +26,9 @@ rdkafka = { version = "0.34.0", features = ["sasl"]  }
 #openssl-sys = { version = "0.9", features = ["vendored"] }
 #openssl = { version = "0.10", features = ["vendored", "v111"] }
 
+#  Ahash hashmap
+ahash = "0.8.3"
+
 # uuid
 uuid = { version = "1.4.1", features = ["v4"] }
 # postgres
@@ -45,11 +48,11 @@ thiserror = "1.0.31"
 mockall = "0.11.0"
 
 # internal crates
-logger =              { path = "../logger" }
-metrics =             { path = "../metrics" }
-talos_certifier =     { path = "../talos_certifier" }
-talos_suffix =        { path = "../talos_suffix" }
-talos_common_utils =  { path = "../talos_common_utils" }
+logger = { path = "../logger" }
+metrics = { path = "../metrics" }
+talos_certifier = { path = "../talos_certifier" }
+talos_suffix = { path = "../talos_suffix" }
+talos_common_utils = { path = "../talos_common_utils" }
 talos_rdkafka_utils = { path = "../talos_rdkafka_utils" }
 
 

--- a/packages/talos_certifier_adapters/src/bin/histogram_decision_timeline_from_kafka.rs
+++ b/packages/talos_certifier_adapters/src/bin/histogram_decision_timeline_from_kafka.rs
@@ -74,18 +74,19 @@ async fn main() -> Result<(), String> {
             _ => break,
         };
 
-        if let ChannelMessage::Decision(_, msg) = message {
+        if let ChannelMessage::Decision(decision) = message {
+            let decision_message = decision.message;
             // log::warn!("Decision {:?}", msg_decision);
             item_number += 1;
             if item_number % progress_frequency == 0 {
                 log::warn!("Progress: {} of {}", item_number, total_decisions);
             }
-            hist_candidate_published.include(&msg.metrics, msg.metrics.candidate_published);
-            hist_candidate_received.include(&msg.metrics, msg.metrics.candidate_received);
-            hist_candidate_processing_started.include(&msg.metrics, msg.metrics.candidate_processing_started);
-            hist_decision_created_at.include(&msg.metrics, msg.metrics.decision_created_at);
-            hist_db_save_started.include(&msg.metrics, msg.metrics.db_save_started);
-            hist_db_save_ended.include(&msg.metrics, msg.metrics.db_save_ended);
+            hist_candidate_published.include(&decision_message.metrics, decision_message.metrics.candidate_published);
+            hist_candidate_received.include(&decision_message.metrics, decision_message.metrics.candidate_received);
+            hist_candidate_processing_started.include(&decision_message.metrics, decision_message.metrics.candidate_processing_started);
+            hist_decision_created_at.include(&decision_message.metrics, decision_message.metrics.decision_created_at);
+            hist_db_save_started.include(&decision_message.metrics, decision_message.metrics.db_save_started);
+            hist_db_save_ended.include(&decision_message.metrics, decision_message.metrics.db_save_ended);
 
             if item_number == total_decisions {
                 break;
@@ -132,9 +133,9 @@ async fn aggregate_timelines(consumer: &mut KafkaConsumer) -> Result<(TimelineAg
             _ => break,
         };
 
-        if let ChannelMessage::Decision(_, msg_decision) = message {
+        if let ChannelMessage::Decision(decision) = message {
             total += 1;
-            aggregates.merge(msg_decision.metrics);
+            aggregates.merge(decision.message.metrics);
         }
     }
 

--- a/packages/talos_certifier_adapters/src/kafka/consumer.rs
+++ b/packages/talos_certifier_adapters/src/kafka/consumer.rs
@@ -111,7 +111,6 @@ impl MessageReciever for KafkaConsumer {
             data: None,
         })?;
 
-        let channel_meta = talos_certifier::ChannelMeta { headers: headers.clone() };
         let channel_msg = match utils::parse_message_variant(message_type).map_err(|e| MessageReceiverError {
             kind: MessageReceiverErrorKind::ParseError,
             version: Some(offset),
@@ -130,7 +129,7 @@ impl MessageReciever for KafkaConsumer {
                 ChannelMessage::Candidate(
                     CandidateChannelMessage {
                         message: msg,
-                        meta: channel_meta,
+                        headers: headers.clone(),
                     }
                     .into(),
                 )
@@ -160,7 +159,7 @@ impl MessageReciever for KafkaConsumer {
                     DecisionChannelMessage {
                         decision_version: offset,
                         message: msg,
-                        meta: channel_meta,
+                        headers: headers.clone(),
                     }
                     .into(),
                 )

--- a/packages/talos_certifier_adapters/src/kafka/producer.rs
+++ b/packages/talos_certifier_adapters/src/kafka/producer.rs
@@ -1,5 +1,4 @@
-use std::collections::HashMap;
-
+use ahash::HashMap;
 use async_trait::async_trait;
 use log::debug;
 use rdkafka::producer::{BaseRecord, DefaultProducerContext, ThreadedProducer};
@@ -30,13 +29,10 @@ impl KafkaProducer {
 //  Message publisher traits
 #[async_trait]
 impl MessagePublisher for KafkaProducer {
-    async fn publish_message(&self, key: &str, value: &str, headers: Option<HashMap<String, String>>) -> Result<(), SystemServiceError> {
+    async fn publish_message(&self, key: &str, value: &str, headers: HashMap<String, String>) -> Result<(), SystemServiceError> {
         let record = BaseRecord::to(&self.topic).payload(value).key(key);
 
-        let record = match headers {
-            Some(x) => record.headers(build_kafka_headers(x)),
-            None => record,
-        };
+        let record = record.headers(build_kafka_headers(headers));
 
         debug!("Preparing to send the Decision Message. ");
         let delivery_result = self

--- a/packages/talos_certifier_adapters/src/kafka/utils.rs
+++ b/packages/talos_certifier_adapters/src/kafka/utils.rs
@@ -1,5 +1,6 @@
-use std::{collections::HashMap, str::FromStr};
+use std::str::FromStr;
 
+use ahash::{HashMap, HashMapExt};
 use rdkafka::{
     message::{BorrowedMessage, Header, Headers, OwnedHeaders},
     Message,
@@ -62,8 +63,7 @@ pub fn parse_message_variant(message_type: &String) -> Result<MessageVariant, Co
 #[cfg(test)]
 mod tests {
 
-    use std::collections::HashMap;
-
+    use ahash::{HashMap, HashMapExt};
     use rdkafka::message::Headers;
     use serde::Deserialize;
     use talos_certifier::{core::MessageVariant, errors::CommonError};

--- a/packages/talos_certifier_adapters/src/mock_certifier_service.rs
+++ b/packages/talos_certifier_adapters/src/mock_certifier_service.rs
@@ -1,7 +1,6 @@
-use std::collections::HashMap;
-
+use ahash::{HashMap, HashMapExt};
 use async_trait::async_trait;
-use talos_certifier::core::{DecisionOutboxChannelMessage, DecisionOutboxChannelMessageMeta, ServiceResult, SystemService};
+use talos_certifier::core::{DecisionOutboxChannelMessage, ServiceResult, SystemService};
 use talos_certifier::errors::{SystemServiceError, SystemServiceErrorKind};
 use talos_certifier::model::metrics::TxProcessingTimeline;
 use talos_certifier::model::{Decision, DecisionMessage};
@@ -46,7 +45,7 @@ impl SystemService for MockCertifierService {
                             duplicate_version: None,
                             metrics: TxProcessingTimeline::default(),
                         };
-                        let decision_outbox_channel_message = DecisionOutboxChannelMessage{ message: decision_message.clone(), meta: DecisionOutboxChannelMessageMeta{headers:HashMap::new()} };
+                        let decision_outbox_channel_message = DecisionOutboxChannelMessage{ message: decision_message.clone(), headers:HashMap::new() };
                         self.decision_outbox_tx
                             .send(decision_outbox_channel_message)
                             .await

--- a/packages/talos_cohort_replicator/src/services/replicator_service.rs
+++ b/packages/talos_cohort_replicator/src/services/replicator_service.rs
@@ -45,13 +45,13 @@ where
                 // 2. Add/update to suffix.
                 match msg {
                     // 2.1 For CM - Install messages on the version
-                    ChannelMessage::Candidate(message) => {
-                        let version = message.version;
-                        replicator.process_consumer_message(version, message.into()).await;
+                    ChannelMessage::Candidate(candidate) => {
+                        let version = candidate.message.version;
+                        replicator.process_consumer_message(version, candidate.message.into()).await;
                     },
                     // 2.2 For DM - Update the decision with outcome + safepoint.
-                    ChannelMessage::Decision(decision_version, decision_message) => {
-                        replicator.process_decision_message(decision_version, decision_message).await;
+                    ChannelMessage::Decision(decision) => {
+                        replicator.process_decision_message(decision.decision_version, decision.message).await;
 
                         if total_items_send == 0 {
                             time_first_item_created_start_ns = OffsetDateTime::now_utc().unix_timestamp_nanos();

--- a/packages/talos_messenger_actions/src/kafka/producer.rs
+++ b/packages/talos_messenger_actions/src/kafka/producer.rs
@@ -1,5 +1,4 @@
-use std::collections::HashMap;
-
+use ahash::HashMap;
 use async_trait::async_trait;
 use log::debug;
 use rdkafka::{
@@ -73,13 +72,10 @@ impl<C: ProducerContext + 'static> KafkaProducer<C> {
 //  Message publisher traits
 #[async_trait]
 impl MessagePublisher for KafkaProducer {
-    async fn publish_message(&self, key: &str, value: &str, headers: Option<HashMap<String, String>>) -> Result<(), SystemServiceError> {
+    async fn publish_message(&self, key: &str, value: &str, headers: HashMap<String, String>) -> Result<(), SystemServiceError> {
         let record = BaseRecord::to(&self.topic).payload(value).key(key);
 
-        let record = match headers {
-            Some(x) => record.headers(build_kafka_headers(x)),
-            None => record,
-        };
+        let record = record.headers(build_kafka_headers(headers));
 
         debug!("Preparing to publish the message. ");
         let delivery_result = self

--- a/packages/talos_messenger_actions/src/kafka/producer.rs
+++ b/packages/talos_messenger_actions/src/kafka/producer.rs
@@ -42,7 +42,7 @@ impl<C: ProducerContext + 'static> KafkaProducer<C> {
         partition: Option<i32>,
         key: Option<&str>,
         value: &str,
-        headers: Option<HashMap<String, String>>,
+        headers: HashMap<String, String>,
         delivery_opaque: C::DeliveryOpaque,
     ) -> Result<(), MessagePublishError> {
         let record = BaseRecord::with_opaque_to(topic, delivery_opaque).payload(value);
@@ -54,10 +54,7 @@ impl<C: ProducerContext + 'static> KafkaProducer<C> {
         let record = if let Some(key_str) = key { record.key(key_str) } else { record };
 
         // Add headers if applicable
-        let record = match headers {
-            Some(x) => record.headers(build_kafka_headers(x)),
-            None => record,
-        };
+        let record = record.headers(build_kafka_headers(headers));
 
         self.producer.send(record).map_err(|(kafka_error, record)| MessagePublishError {
             reason: kafka_error.to_string(),

--- a/packages/talos_messenger_core/src/core.rs
+++ b/packages/talos_messenger_core/src/core.rs
@@ -23,7 +23,7 @@ pub trait MessengerPublisher {
     type Payload;
     type AdditionalData;
     fn get_publish_type(&self) -> PublishActionType;
-    async fn send(&self, version: u64, payload: Self::Payload, additional_data: Self::AdditionalData) -> ();
+    async fn send(&self, version: u64, payload: Self::Payload, headers: HashMap<String, String>, additional_data: Self::AdditionalData) -> ();
 }
 
 /// Trait to be implemented by all services.
@@ -38,6 +38,7 @@ pub trait MessengerSystemService {
 pub struct MessengerCommitActions {
     pub version: u64,
     pub commit_actions: HashMap<String, Value>,
+    pub headers: HashMap<String, String>,
 }
 
 pub enum MessengerChannelFeedback {

--- a/packages/talos_messenger_core/src/services/inbound_service.rs
+++ b/packages/talos_messenger_core/src/services/inbound_service.rs
@@ -149,12 +149,12 @@ where
                     // 2. Add/update to suffix.
                     match msg {
                         // 2.1 For CM - Install messages on the version
-                        ChannelMessage::Candidate(message) => {
+                        ChannelMessage::Candidate(candidate) => {
 
-                            let version = message.version;
-                            if message.version > 0 {
+                            let version = candidate.message.version;
+                            if version > 0 {
                                 // insert item to suffix
-                                let _ = self.suffix.insert(version, message.into());
+                                let _ = self.suffix.insert(version, candidate.message.into());
 
                                 if let Some(item_to_update) = self.suffix.get_mut(version){
                                     if let Some(commit_actions) = &item_to_update.item.candidate.on_commit {
@@ -178,11 +178,11 @@ where
 
                         },
                         // 2.2 For DM - Update the decision with outcome + safepoint.
-                        ChannelMessage::Decision(decision_version, decision_message) => {
-                            let version = decision_message.get_candidate_version();
-                            info!("[Decision Message] Version received = {} and {}", decision_version, version);
+                        ChannelMessage::Decision(decision) => {
+                            let version = decision.message.get_candidate_version();
+                            info!("[Decision Message] Version received = {} and {}", decision.decision_version, version);
 
-                            self.suffix.update_item_decision(version, decision_version, &decision_message);
+                            self.suffix.update_item_decision(version, decision.decision_version, &decision.message);
 
                             self.process_next_actions().await?;
 

--- a/packages/talos_messenger_core/src/services/inbound_service.rs
+++ b/packages/talos_messenger_core/src/services/inbound_service.rs
@@ -42,6 +42,7 @@ where
                     acc.insert(key.to_string(), value.get_payload().clone());
                     acc
                 }),
+                headers: item.headers,
             };
             // send for publishing
             self.tx_actions_channel.send(payload_to_send).await.map_err(|e| MessengerServiceError {
@@ -182,7 +183,9 @@ where
                             let version = decision.message.get_candidate_version();
                             info!("[Decision Message] Version received = {} and {}", decision.decision_version, version);
 
-                            self.suffix.update_item_decision(version, decision.decision_version, &decision.message);
+                            // TODO: GK - no hardcoded filters on headers
+                            let headers: HashMap<String, String> = decision.headers.into_iter().filter(|(key, _)| key.as_str() != "messageType").collect();
+                            self.suffix.update_item_decision(version, decision.decision_version, &decision.message, headers);
 
                             self.process_next_actions().await?;
 


### PR DESCRIPTION
- Pass Candidate message headers to decision message for `certifier`.
- Pass Decision message headers to on-commit publish messages in `messenger`.