### PR TITLE
fix: pass headers received from on_commit actions

### DIFF
--- a/packages/talos_messenger_actions/src/messenger_with_kafka.rs
+++ b/packages/talos_messenger_actions/src/messenger_with_kafka.rs
@@ -51,13 +51,19 @@ where
             total_publish_count: additional_data,
         };
 
+        let mut headers_to_publish = headers;
+
+        if let Some(payload_header) = payload.headers {
+            headers_to_publish.extend(payload_header);
+        }
+
         self.publisher
             .publish_to_topic(
                 &payload.topic,
                 payload.partition,
                 payload.key.as_deref(),
                 payload_str,
-                headers,
+                headers_to_publish,
                 Box::new(delivery_opaque),
             )
             .unwrap();


### PR DESCRIPTION
Currently while the messenger pushes a message to Kafka, it only takes the headers from the candidate message, but doesn't use the headers from on_commit actions.