### PR TITLE
fix: Improve naming of JS exported types

### DIFF
--- a/cohort_banking_initiator_js/src/banking-app.ts
+++ b/cohort_banking_initiator_js/src/banking-app.ts
@@ -7,7 +7,7 @@ import { logger } from "./logger"
 
 import { CapturedItemState, CapturedState, TransferRequest, TransferRequestMessage } from "./model"
 import { SDK_CONFIG as sdkConfig } from "./cfg/config-cohort-sdk"
-import { Initiator, JsCertificationRequestPayload, JsOutOfOrderInstallOutcome, OutOfOrderRequest, TalosSdkError } from "@kindredgroup/cohort_sdk_client"
+import { Initiator, JsCertificationRequest, JsOutOfOrderInstallOutcome, OutOfOrderRequest, TalosSdkError } from "@kindredgroup/cohort_sdk_client"
 
 export class BankingApp {
     private startedAtMs: number = 0
@@ -124,7 +124,7 @@ export class BankingApp {
         return this.handledCount / ((nowMs - this.startedAtMs) / 1_000.0)
     }
 
-    private async createNewRequest(tx: TransferRequest): Promise<JsCertificationRequestPayload> {
+    private async createNewRequest(tx: TransferRequest): Promise<JsCertificationRequest> {
         const state = await this.loadState(tx)
 
         return {

--- a/cohort_sdk_client/README.md
+++ b/cohort_sdk_client/README.md
@@ -91,10 +91,10 @@ async (): Promise<JsCertificationCandidateCallbackResponse>
 ```TypeScript
 export interface JsCertificationCandidateCallbackResponse {
   cancellationReason?: string
-  newRequest?: JsCertificationRequestPayload
+  newRequest?: JsCertificationRequest
 }
 
-export interface JsCertificationRequestPayload {
+export interface JsCertificationRequest {
   candidate: JsCertificationCandidate
   snapshot: number
   timeoutMs: number
@@ -144,11 +144,11 @@ Above mentioned reads, writes and statemap fields together are known as certific
 
 Read about `statemap` in the end of this document. See section [About Statemap](#about-statemap).
 
-### About "JsCertificationRequestPayload"
+### About "JsCertificationRequest"
 
-Talos is making a certification decision purely based on two major pieces of data. 1) the decisions it made to previous requests issued by you or by other cohorts 2) the state of objects in your database. In order to have a full picture, Talos Certifier needs to know not only _the state of your objects taking part in the current transaction_ but also the _global state of your cohort_. The global state is known as the snapshot version. You need to pass your objects (candidate) and your current global state (snapshot). Check this structure `JsCertificationRequestPayload`.
+Talos is making a certification decision purely based on two major pieces of data. 1) the decisions it made to previous requests issued by you or by other cohorts 2) the state of objects in your database. In order to have a full picture, Talos Certifier needs to know not only _the state of your objects taking part in the current transaction_ but also the _global state of your cohort_. The global state is known as the snapshot version. You need to pass your objects (candidate) and your current global state (snapshot). Check this structure `JsCertificationRequest`.
 
-The response to your certification request will be asynchronously received by SDK. However, the async aspect of it is hidden from you for simplicity of usage. Your call to `await .certify(...)` will block until request is available or until it times out. Use the optional config `JsCertificationRequestPayload.timeoutMs` attribute to specify how long you are willing to wait for that specific response. If not provided, then SDK will use value from `JsInitiatorConfig.timeoutMs`.
+The response to your certification request will be asynchronously received by SDK. However, the async aspect of it is hidden from you for simplicity of usage. Your call to `await .certify(...)` will block until request is available or until it times out. Use the optional config `JsCertificationRequest.timeoutMs` attribute to specify how long you are willing to wait for that specific response. If not provided, then SDK will use value from `JsInitiatorConfig.timeoutMs`.
 
 ### About "JsCertificationCandidateCallbackResponse"
 

--- a/cohort_sdk_client/src/index.ts
+++ b/cohort_sdk_client/src/index.ts
@@ -1,10 +1,12 @@
 import { Initiator } from "./initiator"
 import { Replicator } from "./replicator"
 import {
-    JsCertificationRequestPayload,
+    JsCertificationCandidateCallbackResponse,
+    JsCertificationRequest,
     JsCertificationResponse,
     JsDecision,
     JsInitiatorConfig,
+    JsKafkaAction,
     JsKafkaConfig,
     JsReplicatorConfig,
     JsResponseMetadata,
@@ -25,8 +27,10 @@ export {
     Initiator,
     JsDecision,
     JsInitiatorConfig,
+    JsCertificationCandidateCallbackResponse,
     JsCertificationResponse,
-    JsCertificationRequestPayload,
+    JsCertificationRequest,
+    JsKafkaAction,
     JsKafkaConfig,
     JsReplicatorConfig,
     JsResponseMetadata,
@@ -36,4 +40,12 @@ export {
     Replicator,
     SdkErrorKind,
     TalosSdkError,
+}
+
+export class CapturedItemState{
+  constructor(readonly id: string, readonly version: number){}
+}
+
+export class CapturedState{
+  constructor(readonly snapshotVersion: number, readonly items: CapturedItemState[]){}
 }

--- a/packages/cohort_banking/src/app.rs
+++ b/packages/cohort_banking/src/app.rs
@@ -23,7 +23,7 @@ use talos_agent::messaging::api::Decision;
 use crate::{
     callbacks::{certification_candidate_provider::CertificationCandidateProviderImpl, oo_installer::OutOfOrderInstallerImpl},
     examples_support::queue_processor::Handler,
-    model::requests::{CandidateData, CertificationRequest},
+    model::requests::{CandidateData, CertificationRequestContainer},
 };
 
 pub struct BankingApp {
@@ -94,7 +94,7 @@ impl Handler<TransferRequest> for BankingApp {
             }),
         };
 
-        let certification_request = CertificationRequest {
+        let certification_request = CertificationRequestContainer {
             timeout_ms: 0,
             candidate: CandidateData {
                 readset: vec![request.from.clone(), request.to.clone()],

--- a/packages/cohort_banking/src/callbacks/certification_candidate_provider.rs
+++ b/packages/cohort_banking/src/callbacks/certification_candidate_provider.rs
@@ -1,11 +1,11 @@
 use std::sync::Arc;
 
 use banking_common::state::postgres::database::{Database, DatabaseError};
-use cohort_sdk::model::callback::{CertificationCandidate, CertificationCandidateCallbackResponse, CertificationRequestPayload};
+use cohort_sdk::model::callback::{CertificationCandidate, CertificationCandidateCallbackResponse, CertificationRequest};
 use rust_decimal::Decimal;
 use tokio_postgres::Row;
 
-use crate::model::{bank_account::BankAccount, requests::CertificationRequest};
+use crate::model::{bank_account::BankAccount, requests::CertificationRequestContainer};
 
 #[derive(Debug, PartialEq, PartialOrd)]
 pub struct CapturedState {
@@ -132,7 +132,7 @@ impl CertificationCandidateProviderImpl {
         })
     }
 
-    pub async fn get_certification_candidate(&self, request: CertificationRequest) -> Result<CertificationCandidateCallbackResponse, String> {
+    pub async fn get_certification_candidate(&self, request: CertificationRequestContainer) -> Result<CertificationCandidateCallbackResponse, String> {
         // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
         // This example doesn't handle `Cancelled` scenario.
         // If user cancellation is needed, add additional logic in this fn to return `Cancelled` instead of `Proceed` in the result.
@@ -158,7 +158,7 @@ impl CertificationCandidateProviderImpl {
             on_commit: request.candidate.on_commit,
         };
 
-        Ok(CertificationCandidateCallbackResponse::Proceed(CertificationRequestPayload {
+        Ok(CertificationCandidateCallbackResponse::Proceed(CertificationRequest {
             candidate,
             snapshot: state.snapshot_version,
             timeout_ms: request.timeout_ms,

--- a/packages/cohort_banking/src/model/requests.rs
+++ b/packages/cohort_banking/src/model/requests.rs
@@ -12,7 +12,7 @@ pub struct CandidateData {
 }
 
 #[derive(Clone)]
-pub struct CertificationRequest {
+pub struct CertificationRequestContainer {
     pub candidate: CandidateData,
     pub timeout_ms: u64,
 }

--- a/packages/cohort_sdk/src/model/callback.rs
+++ b/packages/cohort_sdk/src/model/callback.rs
@@ -7,11 +7,11 @@ use serde_json::Value;
 #[derive(Debug, PartialEq)]
 pub enum CertificationCandidateCallbackResponse {
     Cancelled(String),
-    Proceed(CertificationRequestPayload),
+    Proceed(CertificationRequest),
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct CertificationRequestPayload {
+pub struct CertificationRequest {
     pub candidate: CertificationCandidate,
     pub snapshot: u64,
     pub timeout_ms: u64,

--- a/packages/cohort_sdk_js/src/initiator/mod.rs
+++ b/packages/cohort_sdk_js/src/initiator/mod.rs
@@ -3,7 +3,7 @@ use crate::sdk_errors::SdkErrorContainer;
 use async_trait::async_trait;
 use cohort_sdk::cohort::Cohort;
 use cohort_sdk::model::callback::{
-    CandidateOnCommitActions, CandidateOnCommitPublishActions, CertificationCandidate, CertificationCandidateCallbackResponse, CertificationRequestPayload,
+    CandidateOnCommitActions, CandidateOnCommitPublishActions, CertificationCandidate, CertificationCandidateCallbackResponse, CertificationRequest,
     KafkaAction, OutOfOrderInstallOutcome, OutOfOrderInstallRequest, OutOfOrderInstaller,
 };
 use cohort_sdk::model::{CertificationResponse, ClientError, Config, ResponseMetadata};
@@ -96,7 +96,7 @@ pub struct JsCandidateOnCommitPublishActions {
 
 // #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[napi(object)]
-pub struct JSCandidateOnCommitActions {
+pub struct JsCandidateOnCommitActions {
     pub publish: Option<JsCandidateOnCommitPublishActions>,
 }
 
@@ -106,7 +106,7 @@ pub struct JsCertificationCandidate {
     pub writeset: Vec<String>,
     pub readvers: Vec<i64>,
     pub statemaps: Option<Vec<HashMap<String, Value>>>,
-    pub on_commit: Option<JSCandidateOnCommitActions>,
+    pub on_commit: Option<JsCandidateOnCommitActions>,
 }
 
 impl From<JsCandidateOnCommitPublishActions> for CandidateOnCommitPublishActions {
@@ -128,8 +128,8 @@ impl From<JsCandidateOnCommitPublishActions> for CandidateOnCommitPublishActions
         CandidateOnCommitPublishActions { kafka: kafka_actions }
     }
 }
-impl From<JSCandidateOnCommitActions> for CandidateOnCommitActions {
-    fn from(val: JSCandidateOnCommitActions) -> Self {
+impl From<JsCandidateOnCommitActions> for CandidateOnCommitActions {
+    fn from(val: JsCandidateOnCommitActions) -> Self {
         CandidateOnCommitActions {
             publish: val.publish.map(|x| x.into()),
         }
@@ -149,15 +149,15 @@ impl From<JsCertificationCandidate> for CertificationCandidate {
 }
 
 #[napi(object)]
-pub struct JsCertificationRequestPayload {
+pub struct JsCertificationRequest {
     pub candidate: JsCertificationCandidate,
     pub snapshot: i64,
     pub timeout_ms: u32,
 }
 
-impl From<JsCertificationRequestPayload> for CertificationRequestPayload {
-    fn from(val: JsCertificationRequestPayload) -> Self {
-        CertificationRequestPayload {
+impl From<JsCertificationRequest> for CertificationRequest {
+    fn from(val: JsCertificationRequest) -> Self {
+        CertificationRequest {
             candidate: val.candidate.into(),
             snapshot: val.snapshot as u64,
             timeout_ms: val.timeout_ms as u64,
@@ -168,7 +168,7 @@ impl From<JsCertificationRequestPayload> for CertificationRequestPayload {
 #[napi(object)]
 pub struct JsCertificationCandidateCallbackResponse {
     pub cancellation_reason: Option<String>,
-    pub new_request: Option<JsCertificationRequestPayload>,
+    pub new_request: Option<JsCertificationRequest>,
 }
 
 #[napi(string_enum)]


### PR DESCRIPTION
Making some improvements to data structure names and exporting a few missed classes.