### PR TITLE
fix: KDT-341 Messenger not pruning suffix on aborts

### DIFF
--- a/examples/messenger_using_kafka/examples/messenger_using_kafka.rs
+++ b/examples/messenger_using_kafka/examples/messenger_using_kafka.rs
@@ -39,6 +39,7 @@ async fn main() {
         allowed_actions,
         channel_buffers: None,
         commit_size: Some(2_000),
+        commit_frequency: None,
     };
 
     messenger_with_kafka(config).await.unwrap();

--- a/packages/talos_certifier/src/ports/message.rs
+++ b/packages/talos_certifier/src/ports/message.rs
@@ -14,7 +14,7 @@ pub trait MessageReciever: SharedPortTraits {
 
     async fn consume_message(&mut self) -> Result<Option<Self::Message>, MessageReceiverError>;
     async fn subscribe(&self) -> Result<(), SystemServiceError>;
-    async fn commit(&self) -> Result<(), SystemServiceError>;
+    fn commit(&self) -> Result<(), Box<SystemServiceError>>;
     fn commit_async(&self) -> Option<JoinHandle<Result<(), SystemServiceError>>>;
     fn update_offset_to_commit(&mut self, offset: i64) -> Result<(), Box<SystemServiceError>>;
     async fn update_savepoint_async(&mut self, offset: i64) -> Result<(), SystemServiceError>;

--- a/packages/talos_certifier/src/services/tests/message_receiver_service.rs
+++ b/packages/talos_certifier/src/services/tests/message_receiver_service.rs
@@ -42,7 +42,7 @@ impl MessageReciever for MockReciever {
         Ok(())
     }
 
-    async fn commit(&self) -> Result<(), SystemServiceError> {
+    fn commit(&self) -> Result<(), Box<SystemServiceError>> {
         Ok(())
     }
     fn commit_async(&self) -> Option<JoinHandle<Result<(), SystemServiceError>>> {

--- a/packages/talos_certifier_adapters/src/kafka/consumer.rs
+++ b/packages/talos_certifier_adapters/src/kafka/consumer.rs
@@ -183,7 +183,7 @@ impl MessageReciever for KafkaConsumer {
         self.consumer.unsubscribe();
     }
 
-    async fn commit(&self) -> Result<(), SystemServiceError> {
+    fn commit(&self) -> Result<(), Box<SystemServiceError>> {
         if self.tpl.count() > 0 {
             self.consumer
                 .commit(&self.tpl, rdkafka::consumer::CommitMode::Async)

--- a/packages/talos_messenger_actions/src/messenger_with_kafka.rs
+++ b/packages/talos_messenger_actions/src/messenger_with_kafka.rs
@@ -108,6 +108,8 @@ pub struct Configuration {
     /// The more often the commit is done has inverse impact on the latency.
     /// Defaults to 5_000.
     pub commit_size: Option<u32>,
+    /// Commit issuing frequency.
+    pub commit_frequency: Option<u32>,
 }
 
 pub async fn messenger_with_kafka(config: Configuration) -> MessengerServiceResult {
@@ -132,7 +134,7 @@ pub async fn messenger_with_kafka(config: Configuration) -> MessengerServiceResu
 
     // START - Inbound service
     let suffix: Suffix<MessengerCandidate> = Suffix::with_config(config.suffix_config.unwrap_or_default());
-    let inbound_service_config = MessengerInboundServiceConfig::new(config.allowed_actions, config.commit_size);
+    let inbound_service_config = MessengerInboundServiceConfig::new(config.allowed_actions, config.commit_size, config.commit_frequency);
     let inbound_service = MessengerInboundService::new(kafka_consumer, tx_actions_channel, rx_feedback_channel, suffix, inbound_service_config);
     // END - Inbound service
 


### PR DESCRIPTION
Updating the messenger pruning and commit logic to handle when there are only abort scenarios.

Also introduce a `commit_frequency` flag to periodically scan and issue commits if there are any remaining records to be committed.

#### Before optimisation and pruning, memory footprint for around 150K messages on topic (candidate + decisions)
![image](https://github.com/user-attachments/assets/4550d4d2-b314-4e60-afd4-269ca1a98604)


#### After optimisations and pruning during abort for the same dataset.
![image](https://github.com/user-attachments/assets/a1e8c317-5130-4645-999c-ec59829bc057)

