### PR TITLE
Adding configurable tracing functionality to cohort SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -661,6 +661,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "cohort_sdk",
+ "litemap",
  "napi",
  "napi-build",
  "napi-derive",
@@ -674,6 +675,7 @@ dependencies = [
  "thiserror 2.0.11",
  "tokio",
  "uuid",
+ "zerofrom",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "agent_client"
-version = "0.2.36-dev"
+version = "0.2.36"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "banking_common"
-version = "0.2.36-dev"
+version = "0.2.36"
 dependencies = [
  "async-trait",
  "deadpool",
@@ -266,7 +266,7 @@ dependencies = [
 
 [[package]]
 name = "banking_replicator"
-version = "0.2.36-dev"
+version = "0.2.36"
 dependencies = [
  "async-trait",
  "banking_common",
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "certifier_kafka_pg"
-version = "0.2.36-dev"
+version = "0.2.36"
 dependencies = [
  "cargo-husky",
  "env_logger",
@@ -535,7 +535,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "cohort_banking"
-version = "0.2.36-dev"
+version = "0.2.36"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "cohort_banking_with_sdk"
-version = "0.2.36-dev"
+version = "0.2.36"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -599,7 +599,7 @@ dependencies = [
 
 [[package]]
 name = "cohort_replicator_kafka_pg"
-version = "0.2.36-dev"
+version = "0.2.36"
 dependencies = [
  "async-trait",
  "banking_common",
@@ -624,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "cohort_sdk"
-version = "0.2.36-dev"
+version = "0.2.36"
 dependencies = [
  "async-trait",
  "axum",
@@ -656,7 +656,7 @@ dependencies = [
 
 [[package]]
 name = "cohort_sdk_js"
-version = "0.2.36-dev"
+version = "0.2.36"
 dependencies = [
  "async-trait",
  "chrono",
@@ -977,7 +977,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "examples_support"
-version = "0.2.36-dev"
+version = "0.2.36"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -1696,7 +1696,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "messenger_using_kafka"
-version = "0.2.36-dev"
+version = "0.2.36"
 dependencies = [
  "ahash 0.8.11",
  "async-trait",
@@ -3157,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "talos_agent"
-version = "0.2.36-dev"
+version = "0.2.36"
 dependencies = [
  "async-trait",
  "mockall",
@@ -3179,7 +3179,7 @@ dependencies = [
 
 [[package]]
 name = "talos_certifier"
-version = "0.2.36-dev"
+version = "0.2.36"
 dependencies = [
  "ahash 0.8.11",
  "async-trait",
@@ -3200,7 +3200,7 @@ dependencies = [
 
 [[package]]
 name = "talos_certifier_adapters"
-version = "0.2.36-dev"
+version = "0.2.36"
 dependencies = [
  "ahash 0.8.11",
  "async-trait",
@@ -3228,7 +3228,7 @@ dependencies = [
 
 [[package]]
 name = "talos_cohort_replicator"
-version = "0.2.36-dev"
+version = "0.2.36"
 dependencies = [
  "ahash 0.8.11",
  "async-trait",
@@ -3250,7 +3250,7 @@ dependencies = [
 
 [[package]]
 name = "talos_common_utils"
-version = "0.2.36-dev"
+version = "0.2.36"
 dependencies = [
  "env_logger",
  "log",
@@ -3259,7 +3259,7 @@ dependencies = [
 
 [[package]]
 name = "talos_messenger_actions"
-version = "0.2.36-dev"
+version = "0.2.36"
 dependencies = [
  "ahash 0.8.11",
  "async-trait",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "talos_messenger_core"
-version = "0.2.36-dev"
+version = "0.2.36"
 dependencies = [
  "ahash 0.8.11",
  "async-trait",
@@ -3316,7 +3316,7 @@ dependencies = [
 
 [[package]]
 name = "talos_metrics"
-version = "0.2.36-dev"
+version = "0.2.36"
 dependencies = [
  "env_logger",
  "log",
@@ -3332,7 +3332,7 @@ dependencies = [
 
 [[package]]
 name = "talos_rdkafka_utils"
-version = "0.2.36-dev"
+version = "0.2.36"
 dependencies = [
  "async-trait",
  "criterion 0.5.1",
@@ -3349,7 +3349,7 @@ dependencies = [
 
 [[package]]
 name = "talos_suffix"
-version = "0.2.36-dev"
+version = "0.2.36"
 dependencies = [
  "async-trait",
  "criterion 0.4.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "agent_client"
-version = "0.2.36"
+version = "0.2.37-dev"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "banking_common"
-version = "0.2.36"
+version = "0.2.37-dev"
 dependencies = [
  "async-trait",
  "deadpool",
@@ -266,7 +266,7 @@ dependencies = [
 
 [[package]]
 name = "banking_replicator"
-version = "0.2.36"
+version = "0.2.37-dev"
 dependencies = [
  "async-trait",
  "banking_common",
@@ -535,7 +535,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "cohort_banking"
-version = "0.2.36"
+version = "0.2.37-dev"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -624,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "cohort_sdk"
-version = "0.2.36"
+version = "0.2.37-dev"
 dependencies = [
  "async-trait",
  "axum",
@@ -656,7 +656,7 @@ dependencies = [
 
 [[package]]
 name = "cohort_sdk_js"
-version = "0.2.36"
+version = "0.2.37-dev"
 dependencies = [
  "async-trait",
  "chrono",
@@ -977,7 +977,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "examples_support"
-version = "0.2.36"
+version = "0.2.37-dev"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -3157,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "talos_agent"
-version = "0.2.36"
+version = "0.2.37-dev"
 dependencies = [
  "async-trait",
  "mockall",
@@ -3179,7 +3179,7 @@ dependencies = [
 
 [[package]]
 name = "talos_certifier"
-version = "0.2.36"
+version = "0.2.37-dev"
 dependencies = [
  "ahash 0.8.11",
  "async-trait",
@@ -3200,7 +3200,7 @@ dependencies = [
 
 [[package]]
 name = "talos_certifier_adapters"
-version = "0.2.36"
+version = "0.2.37-dev"
 dependencies = [
  "ahash 0.8.11",
  "async-trait",
@@ -3228,7 +3228,7 @@ dependencies = [
 
 [[package]]
 name = "talos_cohort_replicator"
-version = "0.2.36"
+version = "0.2.37-dev"
 dependencies = [
  "ahash 0.8.11",
  "async-trait",
@@ -3250,7 +3250,7 @@ dependencies = [
 
 [[package]]
 name = "talos_common_utils"
-version = "0.2.36"
+version = "0.2.37-dev"
 dependencies = [
  "env_logger",
  "log",
@@ -3259,7 +3259,7 @@ dependencies = [
 
 [[package]]
 name = "talos_messenger_actions"
-version = "0.2.36"
+version = "0.2.37-dev"
 dependencies = [
  "ahash 0.8.11",
  "async-trait",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "talos_messenger_core"
-version = "0.2.36"
+version = "0.2.37-dev"
 dependencies = [
  "ahash 0.8.11",
  "async-trait",
@@ -3316,7 +3316,7 @@ dependencies = [
 
 [[package]]
 name = "talos_metrics"
-version = "0.2.36"
+version = "0.2.37-dev"
 dependencies = [
  "env_logger",
  "log",
@@ -3332,7 +3332,7 @@ dependencies = [
 
 [[package]]
 name = "talos_rdkafka_utils"
-version = "0.2.36"
+version = "0.2.37-dev"
 dependencies = [
  "async-trait",
  "criterion 0.5.1",
@@ -3349,7 +3349,7 @@ dependencies = [
 
 [[package]]
 name = "talos_suffix"
-version = "0.2.36"
+version = "0.2.37-dev"
 dependencies = [
  "async-trait",
  "criterion 0.4.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "agent_client"
-version = "0.2.35-dev"
+version = "0.2.35"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "banking_common"
-version = "0.2.35-dev"
+version = "0.2.35"
 dependencies = [
  "async-trait",
  "deadpool",
@@ -266,7 +266,7 @@ dependencies = [
 
 [[package]]
 name = "banking_replicator"
-version = "0.2.35-dev"
+version = "0.2.35"
 dependencies = [
  "async-trait",
  "banking_common",
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "certifier_kafka_pg"
-version = "0.2.35-dev"
+version = "0.2.35"
 dependencies = [
  "cargo-husky",
  "env_logger",
@@ -535,7 +535,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "cohort_banking"
-version = "0.2.35-dev"
+version = "0.2.35"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "cohort_banking_with_sdk"
-version = "0.2.35-dev"
+version = "0.2.35"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -599,7 +599,7 @@ dependencies = [
 
 [[package]]
 name = "cohort_replicator_kafka_pg"
-version = "0.2.35-dev"
+version = "0.2.35"
 dependencies = [
  "async-trait",
  "banking_common",
@@ -624,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "cohort_sdk"
-version = "0.2.35-dev"
+version = "0.2.35"
 dependencies = [
  "async-trait",
  "axum",
@@ -656,7 +656,7 @@ dependencies = [
 
 [[package]]
 name = "cohort_sdk_js"
-version = "0.2.35-dev"
+version = "0.2.35"
 dependencies = [
  "async-trait",
  "chrono",
@@ -977,7 +977,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "examples_support"
-version = "0.2.35-dev"
+version = "0.2.35"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -1696,7 +1696,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "messenger_using_kafka"
-version = "0.2.35-dev"
+version = "0.2.35"
 dependencies = [
  "ahash 0.8.11",
  "async-trait",
@@ -3157,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "talos_agent"
-version = "0.2.35-dev"
+version = "0.2.35"
 dependencies = [
  "async-trait",
  "mockall",
@@ -3179,7 +3179,7 @@ dependencies = [
 
 [[package]]
 name = "talos_certifier"
-version = "0.2.35-dev"
+version = "0.2.35"
 dependencies = [
  "ahash 0.8.11",
  "async-trait",
@@ -3200,7 +3200,7 @@ dependencies = [
 
 [[package]]
 name = "talos_certifier_adapters"
-version = "0.2.35-dev"
+version = "0.2.35"
 dependencies = [
  "ahash 0.8.11",
  "async-trait",
@@ -3228,7 +3228,7 @@ dependencies = [
 
 [[package]]
 name = "talos_cohort_replicator"
-version = "0.2.35-dev"
+version = "0.2.35"
 dependencies = [
  "ahash 0.8.11",
  "async-trait",
@@ -3250,7 +3250,7 @@ dependencies = [
 
 [[package]]
 name = "talos_common_utils"
-version = "0.2.35-dev"
+version = "0.2.35"
 dependencies = [
  "env_logger",
  "log",
@@ -3259,7 +3259,7 @@ dependencies = [
 
 [[package]]
 name = "talos_messenger_actions"
-version = "0.2.35-dev"
+version = "0.2.35"
 dependencies = [
  "ahash 0.8.11",
  "async-trait",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "talos_messenger_core"
-version = "0.2.35-dev"
+version = "0.2.35"
 dependencies = [
  "ahash 0.8.11",
  "async-trait",
@@ -3316,7 +3316,7 @@ dependencies = [
 
 [[package]]
 name = "talos_metrics"
-version = "0.2.35-dev"
+version = "0.2.35"
 dependencies = [
  "env_logger",
  "log",
@@ -3332,7 +3332,7 @@ dependencies = [
 
 [[package]]
 name = "talos_rdkafka_utils"
-version = "0.2.35-dev"
+version = "0.2.35"
 dependencies = [
  "async-trait",
  "criterion 0.5.1",
@@ -3349,7 +3349,7 @@ dependencies = [
 
 [[package]]
 name = "talos_suffix"
-version = "0.2.35-dev"
+version = "0.2.35"
 dependencies = [
  "async-trait",
  "criterion 0.4.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "agent_client"
-version = "0.2.35"
+version = "0.2.36-dev"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "banking_common"
-version = "0.2.35"
+version = "0.2.36-dev"
 dependencies = [
  "async-trait",
  "deadpool",
@@ -266,7 +266,7 @@ dependencies = [
 
 [[package]]
 name = "banking_replicator"
-version = "0.2.35"
+version = "0.2.36-dev"
 dependencies = [
  "async-trait",
  "banking_common",
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "certifier_kafka_pg"
-version = "0.2.35"
+version = "0.2.36-dev"
 dependencies = [
  "cargo-husky",
  "env_logger",
@@ -535,7 +535,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "cohort_banking"
-version = "0.2.35"
+version = "0.2.36-dev"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "cohort_banking_with_sdk"
-version = "0.2.35"
+version = "0.2.36-dev"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -599,7 +599,7 @@ dependencies = [
 
 [[package]]
 name = "cohort_replicator_kafka_pg"
-version = "0.2.35"
+version = "0.2.36-dev"
 dependencies = [
  "async-trait",
  "banking_common",
@@ -624,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "cohort_sdk"
-version = "0.2.35"
+version = "0.2.36-dev"
 dependencies = [
  "async-trait",
  "axum",
@@ -656,7 +656,7 @@ dependencies = [
 
 [[package]]
 name = "cohort_sdk_js"
-version = "0.2.35"
+version = "0.2.36-dev"
 dependencies = [
  "async-trait",
  "chrono",
@@ -977,7 +977,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "examples_support"
-version = "0.2.35"
+version = "0.2.36-dev"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -1696,7 +1696,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "messenger_using_kafka"
-version = "0.2.35"
+version = "0.2.36-dev"
 dependencies = [
  "ahash 0.8.11",
  "async-trait",
@@ -3157,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "talos_agent"
-version = "0.2.35"
+version = "0.2.36-dev"
 dependencies = [
  "async-trait",
  "mockall",
@@ -3179,7 +3179,7 @@ dependencies = [
 
 [[package]]
 name = "talos_certifier"
-version = "0.2.35"
+version = "0.2.36-dev"
 dependencies = [
  "ahash 0.8.11",
  "async-trait",
@@ -3200,7 +3200,7 @@ dependencies = [
 
 [[package]]
 name = "talos_certifier_adapters"
-version = "0.2.35"
+version = "0.2.36-dev"
 dependencies = [
  "ahash 0.8.11",
  "async-trait",
@@ -3228,7 +3228,7 @@ dependencies = [
 
 [[package]]
 name = "talos_cohort_replicator"
-version = "0.2.35"
+version = "0.2.36-dev"
 dependencies = [
  "ahash 0.8.11",
  "async-trait",
@@ -3250,7 +3250,7 @@ dependencies = [
 
 [[package]]
 name = "talos_common_utils"
-version = "0.2.35"
+version = "0.2.36-dev"
 dependencies = [
  "env_logger",
  "log",
@@ -3259,7 +3259,7 @@ dependencies = [
 
 [[package]]
 name = "talos_messenger_actions"
-version = "0.2.35"
+version = "0.2.36-dev"
 dependencies = [
  "ahash 0.8.11",
  "async-trait",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "talos_messenger_core"
-version = "0.2.35"
+version = "0.2.36-dev"
 dependencies = [
  "ahash 0.8.11",
  "async-trait",
@@ -3316,7 +3316,7 @@ dependencies = [
 
 [[package]]
 name = "talos_metrics"
-version = "0.2.35"
+version = "0.2.36-dev"
 dependencies = [
  "env_logger",
  "log",
@@ -3332,7 +3332,7 @@ dependencies = [
 
 [[package]]
 name = "talos_rdkafka_utils"
-version = "0.2.35"
+version = "0.2.36-dev"
 dependencies = [
  "async-trait",
  "criterion 0.5.1",
@@ -3349,7 +3349,7 @@ dependencies = [
 
 [[package]]
 name = "talos_suffix"
-version = "0.2.35"
+version = "0.2.36-dev"
 dependencies = [
  "async-trait",
  "criterion 0.4.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,8 +26,8 @@ dependencies = [
  "env_logger",
  "examples_support",
  "log",
- "rand",
- "rdkafka",
+ "rand 0.8.5",
+ "rdkafka 0.34.0",
  "serde",
  "serde_json",
  "strum 0.25.0",
@@ -44,7 +44,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
 ]
@@ -56,10 +56,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -97,6 +97,12 @@ name = "anstyle"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anyhow"
+version = "1.0.96"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b964d184e89d9b6b67dd2715bc8e74cf3107fb2b529990c90cf517326150bf4"
 
 [[package]]
 name = "arrayvec"
@@ -149,6 +155,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,6 +176,61 @@ name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "backtrace"
@@ -209,9 +276,9 @@ dependencies = [
  "env_logger",
  "futures",
  "log",
- "opentelemetry",
+ "opentelemetry 0.20.0",
  "opentelemetry_api",
- "opentelemetry_sdk",
+ "opentelemetry_sdk 0.20.0",
  "refinery",
  "rust_decimal",
  "serde",
@@ -477,10 +544,10 @@ dependencies = [
  "env_logger",
  "futures",
  "log",
- "opentelemetry",
+ "opentelemetry 0.20.0",
  "opentelemetry_api",
- "opentelemetry_sdk",
- "rand",
+ "opentelemetry_sdk 0.20.0",
+ "rand 0.8.5",
  "refinery",
  "rust_decimal",
  "serde",
@@ -510,12 +577,12 @@ dependencies = [
  "env_logger",
  "examples_support",
  "log",
- "opentelemetry",
- "opentelemetry-stdout",
+ "opentelemetry 0.20.0",
+ "opentelemetry-stdout 0.1.0",
  "opentelemetry_api",
- "opentelemetry_sdk",
- "rand",
- "rdkafka",
+ "opentelemetry_sdk 0.20.0",
+ "rand 0.8.5",
+ "rdkafka 0.34.0",
  "rust_decimal",
  "serde",
  "serde_json",
@@ -540,7 +607,7 @@ dependencies = [
  "cohort_banking",
  "env_logger",
  "log",
- "rdkafka",
+ "rdkafka 0.34.0",
  "rust_decimal",
  "serde",
  "serde_json",
@@ -560,24 +627,30 @@ name = "cohort_sdk"
 version = "0.2.35-dev"
 dependencies = [
  "async-trait",
- "env_logger",
+ "axum",
  "futures",
- "log",
- "opentelemetry",
- "opentelemetry_api",
- "opentelemetry_sdk",
- "rand",
- "rdkafka",
+ "opentelemetry 0.28.0",
+ "opentelemetry-otlp",
+ "opentelemetry-stdout 0.28.0",
+ "opentelemetry_sdk 0.28.0",
+ "rand 0.9.0",
+ "rdkafka 0.37.0",
  "serde",
  "serde_json",
- "strum 0.25.0",
+ "strum 0.27.1",
  "talos_agent",
  "talos_certifier",
  "talos_cohort_replicator",
  "talos_metrics",
  "talos_rdkafka_utils",
+ "thiserror 2.0.11",
  "time",
  "tokio",
+ "tonic",
+ "tracing",
+ "tracing-bunyan-formatter",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
  "uuid",
 ]
 
@@ -588,9 +661,6 @@ dependencies = [
  "async-trait",
  "chrono",
  "cohort_sdk",
- "env_logger",
- "litemap",
- "log",
  "napi",
  "napi-build",
  "napi-derive",
@@ -601,10 +671,9 @@ dependencies = [
  "talos_certifier_adapters",
  "talos_cohort_replicator",
  "talos_rdkafka_utils",
- "thiserror",
+ "thiserror 2.0.11",
  "tokio",
  "uuid",
- "zerofrom",
 ]
 
 [[package]]
@@ -917,7 +986,7 @@ dependencies = [
  "rust_decimal",
  "strum 0.24.1",
  "talos_metrics",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
  "tokio",
  "tokio-postgres",
@@ -938,6 +1007,12 @@ checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
@@ -1060,6 +1135,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ebd34e35c46e00bb73e81363248d627782724609fe1b6396f553f68fe3862e"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1067,7 +1152,19 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1075,6 +1172,31 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
+name = "h2"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.7.1",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
 
 [[package]]
 name = "half"
@@ -1114,6 +1236,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1144,10 +1272,109 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2d708df4e7140240a16cd6ab0ab65c972d7433ab77819ea693fde9c43811e2a"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "hyper"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -1333,6 +1560,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
 name = "is-terminal"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1429,6 +1662,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1452,7 +1700,7 @@ dependencies = [
  "async-trait",
  "env_logger",
  "log",
- "rdkafka",
+ "rdkafka 0.34.0",
  "serde",
  "serde_json",
  "talos_certifier",
@@ -1464,6 +1712,12 @@ dependencies = [
  "talos_suffix",
  "tokio",
 ]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1481,7 +1735,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -1514,9 +1768,9 @@ dependencies = [
 
 [[package]]
 name = "multimap"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1a5d38b9b352dbd913288736af36af41c48d61b1a8cd34bcecd727561b7d511"
+checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 dependencies = [
  "serde",
 ]
@@ -1587,6 +1841,16 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
 
 [[package]]
 name = "num-conv"
@@ -1674,7 +1938,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9591d937bc0e6d2feb6f71a559540ab300ea49955229c347a517a28d27784c54"
 dependencies = [
  "opentelemetry_api",
- "opentelemetry_sdk",
+ "opentelemetry_sdk 0.20.0",
+]
+
+[[package]]
+name = "opentelemetry"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "236e667b670a5cdf90c258f5a55794ec5ac5027e960c224bff8367a59e1e6426"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.11",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8863faf2910030d139fb48715ad5ff2f35029fc5f244f6d5f689ddcf4d26253"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry 0.28.0",
+ "reqwest",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bef114c6d41bea83d6dc60eb41720eedd0261a67af57b66dd2b84ac46c01d91"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "http",
+ "opentelemetry 0.28.0",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk 0.28.0",
+ "prost",
+ "reqwest",
+ "thiserror 2.0.11",
+ "tokio",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f8870d3024727e99212eb3bb1762ec16e255e3e6f58eeb3dc8db1aa226746d"
+dependencies = [
+ "opentelemetry 0.28.0",
+ "opentelemetry_sdk 0.28.0",
+ "prost",
+ "tonic",
 ]
 
 [[package]]
@@ -1685,10 +2010,25 @@ checksum = "8bd550321bc0f9d3f6dcbfe5c75262789de5b3e2776da2cbcfd2392aa05db0c6"
 dependencies = [
  "async-trait",
  "opentelemetry_api",
- "opentelemetry_sdk",
+ "opentelemetry_sdk 0.20.0",
  "ordered-float",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "opentelemetry-stdout"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb0e5a5132e4b80bf037a78e3e12c8402535199f5de490d0c38f7eac71bc831"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "futures-util",
+ "opentelemetry 0.28.0",
+ "opentelemetry_sdk 0.28.0",
+ "serde",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -1703,7 +2043,7 @@ dependencies = [
  "js-sys",
  "once_cell",
  "pin-project-lite",
- "thiserror",
+ "thiserror 1.0.69",
  "urlencoding",
 ]
 
@@ -1722,11 +2062,32 @@ dependencies = [
  "opentelemetry_api",
  "ordered-float",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "regex",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84dfad6042089c7fc1f6118b7040dc2eb4ab520abbf410b79dc481032af39570"
+dependencies = [
+ "async-trait",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "opentelemetry 0.28.0",
+ "percent-encoding",
+ "rand 0.8.5",
+ "serde_json",
+ "thiserror 2.0.11",
+ "tokio",
+ "tokio-stream",
+ "tracing",
 ]
 
 [[package]]
@@ -1753,6 +2114,12 @@ name = "os_str_bytes"
 version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -1799,6 +2166,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfe2e71e1471fe07709406bf725f710b02927c9c54b2b5b2ec0e8087d97c327d"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e859e6e5bd50440ab63c47e3ebabc90f26251f7c73c3d3e837b74a1cc3fa67"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1860,7 +2247,7 @@ dependencies = [
  "hmac",
  "md-5",
  "memchr",
- "rand",
+ "rand 0.8.5",
  "sha2",
  "stringprep",
 ]
@@ -1891,7 +2278,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -1943,6 +2330,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1984,8 +2394,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.2",
+ "zerocopy 0.8.21",
 ]
 
 [[package]]
@@ -1995,7 +2416,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.2",
 ]
 
 [[package]]
@@ -2004,7 +2435,17 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a509b1a2ffbe92afab0e55c8fd99dea1c280e8171bd2d88682bb20bc41cbc2c"
+dependencies = [
+ "getrandom 0.3.1",
+ "zerocopy 0.8.21",
 ]
 
 [[package]]
@@ -2032,6 +2473,24 @@ name = "rdkafka"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053adfa02fab06e86c01d586cc68aa47ee0ff4489a59469081dc12cbcde578bf"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "libc",
+ "log",
+ "rdkafka-sys",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "slab",
+ "tokio",
+]
+
+[[package]]
+name = "rdkafka"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14b52c81ac3cac39c9639b95c20452076e74b8d9a71bc6fc4d83407af2ea6fff"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -2090,7 +2549,7 @@ dependencies = [
  "regex",
  "serde",
  "siphasher",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
  "tokio",
  "tokio-postgres",
@@ -2105,7 +2564,7 @@ version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd81f69687fe8a1fa10995108b3ffc7cdbd63e682a4f8fbfd1020130780d7e17"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "refinery-core",
@@ -2121,8 +2580,17 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -2133,8 +2601,14 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -2149,6 +2623,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
 dependencies = [
  "bytecheck",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower 0.5.2",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2191,7 +2702,7 @@ dependencies = [
  "bytes",
  "num-traits",
  "postgres-types",
- "rand",
+ "rand 0.8.5",
  "rkyv",
  "serde",
  "serde_json",
@@ -2296,11 +2807,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+dependencies = [
+ "itoa",
+ "serde",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
  "serde",
 ]
 
@@ -2338,6 +2871,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -2438,12 +2980,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+dependencies = [
+ "strum_macros 0.27.1",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -2456,7 +3007,20 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
- "heck",
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
+dependencies = [
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -2570,6 +3134,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2585,19 +3158,20 @@ name = "talos_agent"
 version = "0.2.35-dev"
 dependencies = [
  "async-trait",
- "env_logger",
- "log",
  "mockall",
  "multimap",
- "rdkafka",
+ "opentelemetry 0.28.0",
+ "rdkafka 0.34.0",
  "serde",
  "serde_json",
- "strum 0.25.0",
+ "strum 0.27.1",
  "talos_rdkafka_utils",
- "thiserror",
+ "thiserror 2.0.11",
  "time",
  "tokio",
  "tokio-test",
+ "tracing",
+ "tracing-opentelemetry",
  "uuid",
 ]
 
@@ -2616,7 +3190,7 @@ dependencies = [
  "serde_json",
  "strum 0.24.1",
  "talos_suffix",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
  "tokio",
  "tokio-test",
@@ -2633,7 +3207,7 @@ dependencies = [
  "futures-util",
  "log",
  "mockall",
- "rdkafka",
+ "rdkafka 0.34.0",
  "refinery",
  "serde",
  "serde_json",
@@ -2643,7 +3217,7 @@ dependencies = [
  "talos_metrics",
  "talos_rdkafka_utils",
  "talos_suffix",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
  "tokio",
  "tokio-postgres",
@@ -2660,13 +3234,13 @@ dependencies = [
  "indexmap 2.7.1",
  "log",
  "mockall",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "strum 0.25.0",
  "talos_certifier",
  "talos_suffix",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
  "tokio",
  "tokio-test",
@@ -2694,8 +3268,8 @@ dependencies = [
  "litemap",
  "log",
  "mockall",
- "rand",
- "rdkafka",
+ "rand 0.8.5",
+ "rdkafka 0.34.0",
  "serde",
  "serde_json",
  "strum 0.25.0",
@@ -2705,7 +3279,7 @@ dependencies = [
  "talos_messenger_core",
  "talos_rdkafka_utils",
  "talos_suffix",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
  "tokio",
  "tokio-test",
@@ -2724,15 +3298,15 @@ dependencies = [
  "indexmap 2.7.1",
  "log",
  "mockall",
- "rand",
- "rdkafka",
+ "rand 0.8.5",
+ "rdkafka 0.34.0",
  "serde",
  "serde_json",
  "strum 0.25.0",
  "talos_certifier",
  "talos_common_utils",
  "talos_suffix",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
  "tokio",
  "tokio-test",
@@ -2745,10 +3319,10 @@ dependencies = [
  "env_logger",
  "log",
  "once_cell",
- "opentelemetry",
- "opentelemetry-stdout",
+ "opentelemetry 0.20.0",
+ "opentelemetry-stdout 0.1.0",
  "opentelemetry_api",
- "opentelemetry_sdk",
+ "opentelemetry_sdk 0.20.0",
  "serde",
  "serde_json",
  "time",
@@ -2763,10 +3337,10 @@ dependencies = [
  "env_logger",
  "log",
  "mockall",
- "rdkafka",
+ "rdkafka 0.34.0",
  "serial_test",
  "talos_common_utils",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-test",
 ]
@@ -2782,7 +3356,7 @@ dependencies = [
  "mockall",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-test",
 ]
@@ -2820,7 +3394,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+dependencies = [
+ "thiserror-impl 2.0.11",
 ]
 
 [[package]]
@@ -2832,6 +3415,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.96",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
@@ -2948,7 +3552,7 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "rand",
+ "rand 0.8.5",
  "socket2",
  "tokio",
  "tokio-util",
@@ -3027,11 +3631,90 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "socket2",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3049,13 +3732,109 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-bunyan-formatter"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d637245a0d8774bd48df6482e086c59a8b5348a910c3b0579354045a9d82411"
+dependencies = [
+ "ahash 0.8.11",
+ "gethostname",
+ "log",
+ "serde",
+ "serde_json",
+ "time",
+ "tracing",
+ "tracing-core",
+ "tracing-log 0.1.4",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-core"
 version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
+ "valuable",
 ]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "721f2d2569dce9f3dfbbddee5906941e953bfcdf736a62da3377f5751650cc36"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry 0.28.0",
+ "opentelemetry_sdk 0.28.0",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log 0.2.0",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log 0.2.0",
+ "tracing-serde",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typeid"
@@ -3137,9 +3916,15 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "744018581f9a3454a9e15beb8a33b017183f1e7c0cd170232a2d1453b23a51c4"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "serde",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "value-bag"
@@ -3200,10 +3985,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasite"
@@ -3235,6 +4038,19 @@ dependencies = [
  "quote",
  "syn 2.0.96",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -3274,6 +4090,16 @@ name = "web-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3327,6 +4153,36 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+dependencies = [
+ "windows-result",
+ "windows-strings",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
  "windows-targets",
 ]
 
@@ -3422,6 +4278,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags 2.8.0",
+]
+
+[[package]]
 name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3473,7 +4338,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf01143b2dd5d134f11f545cf9f1431b13b749695cb33bcce051e7568f99478"
+dependencies = [
+ "zerocopy-derive 0.8.21",
 ]
 
 [[package]]
@@ -3481,6 +4355,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712c8386f4f4299382c9abee219bee7084f78fb939d88b6840fcc1320d5f6da2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cohort_sdk_client/package-lock.json
+++ b/cohort_sdk_client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kindredgroup/cohort_sdk_client",
-  "version": "0.2.35",
+  "version": "0.2.36-dev",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kindredgroup/cohort_sdk_client",
-      "version": "0.2.35",
+      "version": "0.2.36-dev",
       "license": "MIT",
       "dependencies": {
         "@kindredgroup/cohort_sdk_js": "^0.2.13",

--- a/cohort_sdk_client/package-lock.json
+++ b/cohort_sdk_client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kindredgroup/cohort_sdk_client",
-  "version": "0.2.36-dev",
+  "version": "0.2.36",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kindredgroup/cohort_sdk_client",
-      "version": "0.2.36-dev",
+      "version": "0.2.36",
       "license": "MIT",
       "dependencies": {
         "@kindredgroup/cohort_sdk_js": "^0.2.13",

--- a/cohort_sdk_client/package-lock.json
+++ b/cohort_sdk_client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kindredgroup/cohort_sdk_client",
-  "version": "0.2.35-dev",
+  "version": "0.2.35",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kindredgroup/cohort_sdk_client",
-      "version": "0.2.35-dev",
+      "version": "0.2.35",
       "license": "MIT",
       "dependencies": {
         "@kindredgroup/cohort_sdk_js": "^0.2.13",

--- a/cohort_sdk_client/package-lock.json
+++ b/cohort_sdk_client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kindredgroup/cohort_sdk_client",
-  "version": "0.2.36",
+  "version": "0.2.37-dev",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kindredgroup/cohort_sdk_client",
-      "version": "0.2.36",
+      "version": "0.2.37-dev",
       "license": "MIT",
       "dependencies": {
         "@kindredgroup/cohort_sdk_js": "^0.2.13",

--- a/cohort_sdk_client/package.json
+++ b/cohort_sdk_client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kindredgroup/cohort_sdk_client",
-  "version": "0.2.36",
+  "version": "0.2.37-dev",
   "author": "Kindredgroup",
   "license": "MIT",
   "description": "The Cohort SDK library for Talos Certifier clients",

--- a/cohort_sdk_client/package.json
+++ b/cohort_sdk_client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kindredgroup/cohort_sdk_client",
-  "version": "0.2.35",
+  "version": "0.2.36-dev",
   "author": "Kindredgroup",
   "license": "MIT",
   "description": "The Cohort SDK library for Talos Certifier clients",

--- a/cohort_sdk_client/package.json
+++ b/cohort_sdk_client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kindredgroup/cohort_sdk_client",
-  "version": "0.2.35-dev",
+  "version": "0.2.35",
   "author": "Kindredgroup",
   "license": "MIT",
   "description": "The Cohort SDK library for Talos Certifier clients",

--- a/cohort_sdk_client/package.json
+++ b/cohort_sdk_client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kindredgroup/cohort_sdk_client",
-  "version": "0.2.36-dev",
+  "version": "0.2.36",
   "author": "Kindredgroup",
   "license": "MIT",
   "description": "The Cohort SDK library for Talos Certifier clients",

--- a/cohort_sdk_client/src/initiator.ts
+++ b/cohort_sdk_client/src/initiator.ts
@@ -19,7 +19,12 @@ export class Initiator {
 
     constructor(readonly impl: InternalInitiator) {}
 
-    async certify(makeNewRequestCallback: () => Promise<JsCertificationCandidateCallbackResponse>, oooInstallCallback: (oooRequest: OutOfOrderRequest) => Promise<JsOutOfOrderInstallOutcome>): Promise<JsCertificationResponse> {
+    // The 'traceParent' parameter allow us to continue span which started on the "JavaScript side"
+    async certify(
+        makeNewRequestCallback: () => Promise<JsCertificationCandidateCallbackResponse>,
+        oooInstallCallback: (oooRequest: OutOfOrderRequest,) => Promise<JsOutOfOrderInstallOutcome>,
+        traceParent?: string
+    ): Promise<JsCertificationResponse> {
         try {
             // This will hide the 'error' parameter from callback (it comes from NAPI).
             const adaptedOooInstallCallback = async (error: Error | null, oooRequest: OutOfOrderRequest): Promise<JsOutOfOrderInstallOutcome> => {
@@ -34,7 +39,7 @@ export class Initiator {
                 }
             }
 
-            return await this.impl.certify(makeNewRequestCallback, adaptedOooInstallCallback)
+            return await this.impl.certify(makeNewRequestCallback, adaptedOooInstallCallback, traceParent)
         } catch (e) {
             const reason: string = e.message
             if (isSdkError(reason)) {

--- a/examples/agent_client/Cargo.toml
+++ b/examples/agent_client/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "agent_client"
-version = "0.2.36-dev"
+version = "0.2.36"
 edition = "2021"
 
 [dev-dependencies]
 
-talos_agent =         { path = "../../packages/talos_agent", version = "0.2.36-dev" }
-talos_rdkafka_utils = { path = "../../packages/talos_rdkafka_utils", version = "0.2.36-dev" }
-examples_support =    { path = "../../packages/examples_support", version = "0.2.36-dev" }
+talos_agent =         { path = "../../packages/talos_agent", version = "0.2.36" }
+talos_rdkafka_utils = { path = "../../packages/talos_rdkafka_utils", version = "0.2.36" }
+examples_support =    { path = "../../packages/examples_support", version = "0.2.36" }
 
 async-channel = { version = "1.8.0" }
 async-trait =   { workspace = true }

--- a/examples/agent_client/Cargo.toml
+++ b/examples/agent_client/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "agent_client"
-version = "0.2.35"
+version = "0.2.36-dev"
 edition = "2021"
 
 [dev-dependencies]
 
-talos_agent =         { path = "../../packages/talos_agent", version = "0.2.35" }
-talos_rdkafka_utils = { path = "../../packages/talos_rdkafka_utils", version = "0.2.35" }
-examples_support =    { path = "../../packages/examples_support", version = "0.2.35" }
+talos_agent =         { path = "../../packages/talos_agent", version = "0.2.36-dev" }
+talos_rdkafka_utils = { path = "../../packages/talos_rdkafka_utils", version = "0.2.36-dev" }
+examples_support =    { path = "../../packages/examples_support", version = "0.2.36-dev" }
 
 async-channel = { version = "1.8.0" }
 async-trait =   { workspace = true }

--- a/examples/agent_client/Cargo.toml
+++ b/examples/agent_client/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "agent_client"
-version = "0.2.36"
+version = "0.2.37-dev"
 edition = "2021"
 
 [dev-dependencies]
 
-talos_agent =         { path = "../../packages/talos_agent", version = "0.2.36" }
-talos_rdkafka_utils = { path = "../../packages/talos_rdkafka_utils", version = "0.2.36" }
-examples_support =    { path = "../../packages/examples_support", version = "0.2.36" }
+talos_agent =         { path = "../../packages/talos_agent", version = "0.2.37-dev" }
+talos_rdkafka_utils = { path = "../../packages/talos_rdkafka_utils", version = "0.2.37-dev" }
+examples_support =    { path = "../../packages/examples_support", version = "0.2.37-dev" }
 
 async-channel = { version = "1.8.0" }
 async-trait =   { workspace = true }

--- a/examples/agent_client/Cargo.toml
+++ b/examples/agent_client/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "agent_client"
-version = "0.2.35-dev"
+version = "0.2.35"
 edition = "2021"
 
 [dev-dependencies]
 
-talos_agent =         { path = "../../packages/talos_agent", version = "0.2.35-dev" }
-talos_rdkafka_utils = { path = "../../packages/talos_rdkafka_utils", version = "0.2.35-dev" }
-examples_support =    { path = "../../packages/examples_support", version = "0.2.35-dev" }
+talos_agent =         { path = "../../packages/talos_agent", version = "0.2.35" }
+talos_rdkafka_utils = { path = "../../packages/talos_rdkafka_utils", version = "0.2.35" }
+examples_support =    { path = "../../packages/examples_support", version = "0.2.35" }
 
 async-channel = { version = "1.8.0" }
 async-trait =   { workspace = true }

--- a/examples/agent_client/examples/agent_client.rs
+++ b/examples/agent_client/examples/agent_client.rs
@@ -7,7 +7,7 @@ use std::{env, sync::Arc, time::Duration};
 use talos_agent::agent::core::TalosAgentImpl;
 use talos_agent::agent::model::{CancelRequestChannelMessage, CertifyRequestChannelMessage};
 use talos_agent::api::{AgentConfig, CandidateData, CertificationRequest, CertificationResponse, TalosAgent, TalosType};
-use talos_agent::messaging::api::DecisionMessage;
+use talos_agent::messaging::api::TraceableDecision;
 use talos_agent::messaging::kafka::KafkaInitializer;
 use talos_agent::metrics::client::MetricsClient;
 use talos_agent::metrics::core::Metrics;
@@ -178,9 +178,9 @@ async fn make_agent(params: LaunchParams) -> impl TalosAgent {
     let tx_certify = SenderWrapper::<CertifyRequestChannelMessage> { tx: tx_certify_ch };
     let rx_certify = ReceiverWrapper::<CertifyRequestChannelMessage> { rx: rx_certify_ch };
 
-    let (tx_decision_ch, rx_decision_ch) = mpsc::channel::<DecisionMessage>(cfg_agent.buffer_size as usize);
-    let tx_decision = SenderWrapper::<DecisionMessage> { tx: tx_decision_ch };
-    let rx_decision = ReceiverWrapper::<DecisionMessage> { rx: rx_decision_ch };
+    let (tx_decision_ch, rx_decision_ch) = mpsc::channel::<TraceableDecision>(cfg_agent.buffer_size as usize);
+    let tx_decision = SenderWrapper::<TraceableDecision> { tx: tx_decision_ch };
+    let rx_decision = ReceiverWrapper::<TraceableDecision> { rx: rx_decision_ch };
 
     let (tx_cancel_ch, rx_cancel_ch) = mpsc::channel::<CancelRequestChannelMessage>(cfg_agent.buffer_size as usize);
     let tx_cancel = SenderWrapper::<CancelRequestChannelMessage> { tx: tx_cancel_ch };

--- a/examples/certifier_kafka_pg/Cargo.toml
+++ b/examples/certifier_kafka_pg/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # [package]
 name = "certifier_kafka_pg"
-version = "0.2.35-dev"
+version = "0.2.35"
 edition = "2021"
 keywords = ["talos"]
 description = "Talos Certifier using Kafka and Pg adapters"
@@ -17,11 +17,11 @@ tokio = { workspace = true }
 refinery = { version = "0.8.7", features = ["tokio-postgres"] }
 
 # internal crates
-talos_certifier = { path = "../../packages/talos_certifier", version = "0.2.35-dev" }
-talos_suffix = { path = "../../packages/talos_suffix", version = "0.2.35-dev" }
-talos_certifier_adapters = { path = "../../packages/talos_certifier_adapters", version = "0.2.35-dev" }
-talos_common_utils = { path = "../../packages/talos_common_utils", version = "0.2.35-dev" }
-talos_rdkafka_utils = { path = "../../packages/talos_rdkafka_utils", version = "0.2.35-dev" }
+talos_certifier = { path = "../../packages/talos_certifier", version = "0.2.35" }
+talos_suffix = { path = "../../packages/talos_suffix", version = "0.2.35" }
+talos_certifier_adapters = { path = "../../packages/talos_certifier_adapters", version = "0.2.35" }
+talos_common_utils = { path = "../../packages/talos_common_utils", version = "0.2.35" }
+talos_rdkafka_utils = { path = "../../packages/talos_rdkafka_utils", version = "0.2.35" }
 
 [dev-dependencies.cargo-husky]
 version = "1"

--- a/examples/certifier_kafka_pg/Cargo.toml
+++ b/examples/certifier_kafka_pg/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # [package]
 name = "certifier_kafka_pg"
-version = "0.2.35"
+version = "0.2.36-dev"
 edition = "2021"
 keywords = ["talos"]
 description = "Talos Certifier using Kafka and Pg adapters"
@@ -17,11 +17,11 @@ tokio = { workspace = true }
 refinery = { version = "0.8.7", features = ["tokio-postgres"] }
 
 # internal crates
-talos_certifier = { path = "../../packages/talos_certifier", version = "0.2.35" }
-talos_suffix = { path = "../../packages/talos_suffix", version = "0.2.35" }
-talos_certifier_adapters = { path = "../../packages/talos_certifier_adapters", version = "0.2.35" }
-talos_common_utils = { path = "../../packages/talos_common_utils", version = "0.2.35" }
-talos_rdkafka_utils = { path = "../../packages/talos_rdkafka_utils", version = "0.2.35" }
+talos_certifier = { path = "../../packages/talos_certifier", version = "0.2.36-dev" }
+talos_suffix = { path = "../../packages/talos_suffix", version = "0.2.36-dev" }
+talos_certifier_adapters = { path = "../../packages/talos_certifier_adapters", version = "0.2.36-dev" }
+talos_common_utils = { path = "../../packages/talos_common_utils", version = "0.2.36-dev" }
+talos_rdkafka_utils = { path = "../../packages/talos_rdkafka_utils", version = "0.2.36-dev" }
 
 [dev-dependencies.cargo-husky]
 version = "1"

--- a/examples/certifier_kafka_pg/Cargo.toml
+++ b/examples/certifier_kafka_pg/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # [package]
 name = "certifier_kafka_pg"
-version = "0.2.36"
+version = "0.2.37-dev"
 edition = "2021"
 keywords = ["talos"]
 description = "Talos Certifier using Kafka and Pg adapters"
@@ -17,11 +17,11 @@ tokio = { workspace = true }
 refinery = { version = "0.8.7", features = ["tokio-postgres"] }
 
 # internal crates
-talos_certifier = { path = "../../packages/talos_certifier", version = "0.2.36" }
-talos_suffix = { path = "../../packages/talos_suffix", version = "0.2.36" }
-talos_certifier_adapters = { path = "../../packages/talos_certifier_adapters", version = "0.2.36" }
-talos_common_utils = { path = "../../packages/talos_common_utils", version = "0.2.36" }
-talos_rdkafka_utils = { path = "../../packages/talos_rdkafka_utils", version = "0.2.36" }
+talos_certifier = { path = "../../packages/talos_certifier", version = "0.2.37-dev" }
+talos_suffix = { path = "../../packages/talos_suffix", version = "0.2.37-dev" }
+talos_certifier_adapters = { path = "../../packages/talos_certifier_adapters", version = "0.2.37-dev" }
+talos_common_utils = { path = "../../packages/talos_common_utils", version = "0.2.37-dev" }
+talos_rdkafka_utils = { path = "../../packages/talos_rdkafka_utils", version = "0.2.37-dev" }
 
 [dev-dependencies.cargo-husky]
 version = "1"

--- a/examples/certifier_kafka_pg/Cargo.toml
+++ b/examples/certifier_kafka_pg/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # [package]
 name = "certifier_kafka_pg"
-version = "0.2.36-dev"
+version = "0.2.36"
 edition = "2021"
 keywords = ["talos"]
 description = "Talos Certifier using Kafka and Pg adapters"
@@ -17,11 +17,11 @@ tokio = { workspace = true }
 refinery = { version = "0.8.7", features = ["tokio-postgres"] }
 
 # internal crates
-talos_certifier = { path = "../../packages/talos_certifier", version = "0.2.36-dev" }
-talos_suffix = { path = "../../packages/talos_suffix", version = "0.2.36-dev" }
-talos_certifier_adapters = { path = "../../packages/talos_certifier_adapters", version = "0.2.36-dev" }
-talos_common_utils = { path = "../../packages/talos_common_utils", version = "0.2.36-dev" }
-talos_rdkafka_utils = { path = "../../packages/talos_rdkafka_utils", version = "0.2.36-dev" }
+talos_certifier = { path = "../../packages/talos_certifier", version = "0.2.36" }
+talos_suffix = { path = "../../packages/talos_suffix", version = "0.2.36" }
+talos_certifier_adapters = { path = "../../packages/talos_certifier_adapters", version = "0.2.36" }
+talos_common_utils = { path = "../../packages/talos_common_utils", version = "0.2.36" }
+talos_rdkafka_utils = { path = "../../packages/talos_rdkafka_utils", version = "0.2.36" }
 
 [dev-dependencies.cargo-husky]
 version = "1"

--- a/examples/cohort_banking_with_sdk/Cargo.toml
+++ b/examples/cohort_banking_with_sdk/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
 name = "cohort_banking_with_sdk"
-version = "0.2.35-dev"
+version = "0.2.35"
 edition = "2021"
 
 [dev-dependencies]
 
-banking_common =           { path = "../../packages/banking_common", version = "0.2.35-dev" }
-cohort_sdk =               { path = "../../packages/cohort_sdk", version = "0.2.35-dev" }
-cohort_banking =           { path = "../../packages/cohort_banking", version = "0.2.35-dev" }
-examples_support =         { path = "../../packages/examples_support", version = "0.2.35-dev" }
-talos_metrics =            { path = "../../packages/talos_metrics", version = "0.2.35-dev" }
-talos_agent =              { path = "../../packages/talos_agent", version = "0.2.35-dev" }
-talos_certifier =          { path = "../../packages/talos_certifier", version = "0.2.35-dev" }
-talos_certifier_adapters = { path = "../../packages/talos_certifier_adapters", version = "0.2.35-dev" }
-talos_rdkafka_utils =      { path = "../../packages/talos_rdkafka_utils", version = "0.2.35-dev" }
+banking_common =           { path = "../../packages/banking_common", version = "0.2.35" }
+cohort_sdk =               { path = "../../packages/cohort_sdk", version = "0.2.35" }
+cohort_banking =           { path = "../../packages/cohort_banking", version = "0.2.35" }
+examples_support =         { path = "../../packages/examples_support", version = "0.2.35" }
+talos_metrics =            { path = "../../packages/talos_metrics", version = "0.2.35" }
+talos_agent =              { path = "../../packages/talos_agent", version = "0.2.35" }
+talos_certifier =          { path = "../../packages/talos_certifier", version = "0.2.35" }
+talos_certifier_adapters = { path = "../../packages/talos_certifier_adapters", version = "0.2.35" }
+talos_rdkafka_utils =      { path = "../../packages/talos_rdkafka_utils", version = "0.2.35" }
 
 async-trait = { workspace = true }
 env_logger =  { workspace = true }

--- a/examples/cohort_banking_with_sdk/Cargo.toml
+++ b/examples/cohort_banking_with_sdk/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
 name = "cohort_banking_with_sdk"
-version = "0.2.35"
+version = "0.2.36-dev"
 edition = "2021"
 
 [dev-dependencies]
 
-banking_common =           { path = "../../packages/banking_common", version = "0.2.35" }
-cohort_sdk =               { path = "../../packages/cohort_sdk", version = "0.2.35" }
-cohort_banking =           { path = "../../packages/cohort_banking", version = "0.2.35" }
-examples_support =         { path = "../../packages/examples_support", version = "0.2.35" }
-talos_metrics =            { path = "../../packages/talos_metrics", version = "0.2.35" }
-talos_agent =              { path = "../../packages/talos_agent", version = "0.2.35" }
-talos_certifier =          { path = "../../packages/talos_certifier", version = "0.2.35" }
-talos_certifier_adapters = { path = "../../packages/talos_certifier_adapters", version = "0.2.35" }
-talos_rdkafka_utils =      { path = "../../packages/talos_rdkafka_utils", version = "0.2.35" }
+banking_common =           { path = "../../packages/banking_common", version = "0.2.36-dev" }
+cohort_sdk =               { path = "../../packages/cohort_sdk", version = "0.2.36-dev" }
+cohort_banking =           { path = "../../packages/cohort_banking", version = "0.2.36-dev" }
+examples_support =         { path = "../../packages/examples_support", version = "0.2.36-dev" }
+talos_metrics =            { path = "../../packages/talos_metrics", version = "0.2.36-dev" }
+talos_agent =              { path = "../../packages/talos_agent", version = "0.2.36-dev" }
+talos_certifier =          { path = "../../packages/talos_certifier", version = "0.2.36-dev" }
+talos_certifier_adapters = { path = "../../packages/talos_certifier_adapters", version = "0.2.36-dev" }
+talos_rdkafka_utils =      { path = "../../packages/talos_rdkafka_utils", version = "0.2.36-dev" }
 
 async-trait = { workspace = true }
 env_logger =  { workspace = true }

--- a/examples/cohort_banking_with_sdk/Cargo.toml
+++ b/examples/cohort_banking_with_sdk/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
 name = "cohort_banking_with_sdk"
-version = "0.2.36-dev"
+version = "0.2.36"
 edition = "2021"
 
 [dev-dependencies]
 
-banking_common =           { path = "../../packages/banking_common", version = "0.2.36-dev" }
-cohort_sdk =               { path = "../../packages/cohort_sdk", version = "0.2.36-dev" }
-cohort_banking =           { path = "../../packages/cohort_banking", version = "0.2.36-dev" }
-examples_support =         { path = "../../packages/examples_support", version = "0.2.36-dev" }
-talos_metrics =            { path = "../../packages/talos_metrics", version = "0.2.36-dev" }
-talos_agent =              { path = "../../packages/talos_agent", version = "0.2.36-dev" }
-talos_certifier =          { path = "../../packages/talos_certifier", version = "0.2.36-dev" }
-talos_certifier_adapters = { path = "../../packages/talos_certifier_adapters", version = "0.2.36-dev" }
-talos_rdkafka_utils =      { path = "../../packages/talos_rdkafka_utils", version = "0.2.36-dev" }
+banking_common =           { path = "../../packages/banking_common", version = "0.2.36" }
+cohort_sdk =               { path = "../../packages/cohort_sdk", version = "0.2.36" }
+cohort_banking =           { path = "../../packages/cohort_banking", version = "0.2.36" }
+examples_support =         { path = "../../packages/examples_support", version = "0.2.36" }
+talos_metrics =            { path = "../../packages/talos_metrics", version = "0.2.36" }
+talos_agent =              { path = "../../packages/talos_agent", version = "0.2.36" }
+talos_certifier =          { path = "../../packages/talos_certifier", version = "0.2.36" }
+talos_certifier_adapters = { path = "../../packages/talos_certifier_adapters", version = "0.2.36" }
+talos_rdkafka_utils =      { path = "../../packages/talos_rdkafka_utils", version = "0.2.36" }
 
 async-trait = { workspace = true }
 env_logger =  { workspace = true }

--- a/examples/cohort_banking_with_sdk/Cargo.toml
+++ b/examples/cohort_banking_with_sdk/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
 name = "cohort_banking_with_sdk"
-version = "0.2.36"
+version = "0.2.37-dev"
 edition = "2021"
 
 [dev-dependencies]
 
-banking_common =           { path = "../../packages/banking_common", version = "0.2.36" }
-cohort_sdk =               { path = "../../packages/cohort_sdk", version = "0.2.36" }
-cohort_banking =           { path = "../../packages/cohort_banking", version = "0.2.36" }
-examples_support =         { path = "../../packages/examples_support", version = "0.2.36" }
-talos_metrics =            { path = "../../packages/talos_metrics", version = "0.2.36" }
-talos_agent =              { path = "../../packages/talos_agent", version = "0.2.36" }
-talos_certifier =          { path = "../../packages/talos_certifier", version = "0.2.36" }
-talos_certifier_adapters = { path = "../../packages/talos_certifier_adapters", version = "0.2.36" }
-talos_rdkafka_utils =      { path = "../../packages/talos_rdkafka_utils", version = "0.2.36" }
+banking_common =           { path = "../../packages/banking_common", version = "0.2.37-dev" }
+cohort_sdk =               { path = "../../packages/cohort_sdk", version = "0.2.37-dev" }
+cohort_banking =           { path = "../../packages/cohort_banking", version = "0.2.37-dev" }
+examples_support =         { path = "../../packages/examples_support", version = "0.2.37-dev" }
+talos_metrics =            { path = "../../packages/talos_metrics", version = "0.2.37-dev" }
+talos_agent =              { path = "../../packages/talos_agent", version = "0.2.37-dev" }
+talos_certifier =          { path = "../../packages/talos_certifier", version = "0.2.37-dev" }
+talos_certifier_adapters = { path = "../../packages/talos_certifier_adapters", version = "0.2.37-dev" }
+talos_rdkafka_utils =      { path = "../../packages/talos_rdkafka_utils", version = "0.2.37-dev" }
 
 async-trait = { workspace = true }
 env_logger =  { workspace = true }

--- a/examples/cohort_banking_with_sdk/examples/cohort_banking_with_sdk.rs
+++ b/examples/cohort_banking_with_sdk/examples/cohort_banking_with_sdk.rs
@@ -5,7 +5,7 @@ use banking_common::model::TransferRequest;
 use banking_common::state::postgres::database_config::DatabaseConfig;
 use cohort_banking::app::BankingApp;
 use cohort_banking::examples_support::queue_processor::QueueProcessor;
-use cohort_sdk::model::{BackoffConfig, Config};
+use cohort_sdk::model::{BackoffConfig, CohortOtelConfig, Config};
 use examples_support::load_generator::models::Generator;
 use examples_support::load_generator::{generator::ControlledRateLoadGenerator, models::StopType};
 
@@ -113,6 +113,7 @@ async fn main() -> Result<(), String> {
         buffer_size: 10_000_000,
         timeout_ms: 600_000,
         kafka: cfg_kafka,
+        otel_telemetry: CohortOtelConfig::default(),
     };
 
     let db_config = DatabaseConfig::from_env(Some("COHORT"))?;

--- a/examples/cohort_replicator_kafka_pg/Cargo.toml
+++ b/examples/cohort_replicator_kafka_pg/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "cohort_replicator_kafka_pg"
-version = "0.2.36-dev"
+version = "0.2.36"
 edition = "2021"
 
 [dev-dependencies]
-banking_common =            { path = "../../packages/banking_common", version = "0.2.36-dev" }
-banking_replicator =        { path = "../../packages/banking_replicator", version = "0.2.36-dev" }
-cohort_banking  =           { path = "../../packages/cohort_banking", version = "0.2.36-dev" }
-talos_cohort_replicator =   { path = "../../packages/talos_cohort_replicator", version = "0.2.36-dev" }
-talos_certifier =           { path = "../../packages/talos_certifier", version = "0.2.36-dev" }
-talos_certifier_adapters =  { path = "../../packages/talos_certifier_adapters", version = "0.2.36-dev" }
-talos_common_utils =        { path = "../../packages/talos_common_utils", version = "0.2.36-dev" }
-talos_rdkafka_utils =       { path = "../../packages/talos_rdkafka_utils", version = "0.2.36-dev" }
+banking_common =            { path = "../../packages/banking_common", version = "0.2.36" }
+banking_replicator =        { path = "../../packages/banking_replicator", version = "0.2.36" }
+cohort_banking  =           { path = "../../packages/cohort_banking", version = "0.2.36" }
+talos_cohort_replicator =   { path = "../../packages/talos_cohort_replicator", version = "0.2.36" }
+talos_certifier =           { path = "../../packages/talos_certifier", version = "0.2.36" }
+talos_certifier_adapters =  { path = "../../packages/talos_certifier_adapters", version = "0.2.36" }
+talos_common_utils =        { path = "../../packages/talos_common_utils", version = "0.2.36" }
+talos_rdkafka_utils =       { path = "../../packages/talos_rdkafka_utils", version = "0.2.36" }
 
 async-trait = { workspace = true }
 env_logger =  { workspace = true }

--- a/examples/cohort_replicator_kafka_pg/Cargo.toml
+++ b/examples/cohort_replicator_kafka_pg/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "cohort_replicator_kafka_pg"
-version = "0.2.35-dev"
+version = "0.2.35"
 edition = "2021"
 
 [dev-dependencies]
-banking_common =            { path = "../../packages/banking_common", version = "0.2.35-dev" }
-banking_replicator =        { path = "../../packages/banking_replicator", version = "0.2.35-dev" }
-cohort_banking  =           { path = "../../packages/cohort_banking", version = "0.2.35-dev" }
-talos_cohort_replicator =   { path = "../../packages/talos_cohort_replicator", version = "0.2.35-dev" }
-talos_certifier =           { path = "../../packages/talos_certifier", version = "0.2.35-dev" }
-talos_certifier_adapters =  { path = "../../packages/talos_certifier_adapters", version = "0.2.35-dev" }
-talos_common_utils =        { path = "../../packages/talos_common_utils", version = "0.2.35-dev" }
-talos_rdkafka_utils =       { path = "../../packages/talos_rdkafka_utils", version = "0.2.35-dev" }
+banking_common =            { path = "../../packages/banking_common", version = "0.2.35" }
+banking_replicator =        { path = "../../packages/banking_replicator", version = "0.2.35" }
+cohort_banking  =           { path = "../../packages/cohort_banking", version = "0.2.35" }
+talos_cohort_replicator =   { path = "../../packages/talos_cohort_replicator", version = "0.2.35" }
+talos_certifier =           { path = "../../packages/talos_certifier", version = "0.2.35" }
+talos_certifier_adapters =  { path = "../../packages/talos_certifier_adapters", version = "0.2.35" }
+talos_common_utils =        { path = "../../packages/talos_common_utils", version = "0.2.35" }
+talos_rdkafka_utils =       { path = "../../packages/talos_rdkafka_utils", version = "0.2.35" }
 
 async-trait = { workspace = true }
 env_logger =  { workspace = true }

--- a/examples/cohort_replicator_kafka_pg/Cargo.toml
+++ b/examples/cohort_replicator_kafka_pg/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "cohort_replicator_kafka_pg"
-version = "0.2.35"
+version = "0.2.36-dev"
 edition = "2021"
 
 [dev-dependencies]
-banking_common =            { path = "../../packages/banking_common", version = "0.2.35" }
-banking_replicator =        { path = "../../packages/banking_replicator", version = "0.2.35" }
-cohort_banking  =           { path = "../../packages/cohort_banking", version = "0.2.35" }
-talos_cohort_replicator =   { path = "../../packages/talos_cohort_replicator", version = "0.2.35" }
-talos_certifier =           { path = "../../packages/talos_certifier", version = "0.2.35" }
-talos_certifier_adapters =  { path = "../../packages/talos_certifier_adapters", version = "0.2.35" }
-talos_common_utils =        { path = "../../packages/talos_common_utils", version = "0.2.35" }
-talos_rdkafka_utils =       { path = "../../packages/talos_rdkafka_utils", version = "0.2.35" }
+banking_common =            { path = "../../packages/banking_common", version = "0.2.36-dev" }
+banking_replicator =        { path = "../../packages/banking_replicator", version = "0.2.36-dev" }
+cohort_banking  =           { path = "../../packages/cohort_banking", version = "0.2.36-dev" }
+talos_cohort_replicator =   { path = "../../packages/talos_cohort_replicator", version = "0.2.36-dev" }
+talos_certifier =           { path = "../../packages/talos_certifier", version = "0.2.36-dev" }
+talos_certifier_adapters =  { path = "../../packages/talos_certifier_adapters", version = "0.2.36-dev" }
+talos_common_utils =        { path = "../../packages/talos_common_utils", version = "0.2.36-dev" }
+talos_rdkafka_utils =       { path = "../../packages/talos_rdkafka_utils", version = "0.2.36-dev" }
 
 async-trait = { workspace = true }
 env_logger =  { workspace = true }

--- a/examples/cohort_replicator_kafka_pg/Cargo.toml
+++ b/examples/cohort_replicator_kafka_pg/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "cohort_replicator_kafka_pg"
-version = "0.2.36"
+version = "0.2.37-dev"
 edition = "2021"
 
 [dev-dependencies]
-banking_common =            { path = "../../packages/banking_common", version = "0.2.36" }
-banking_replicator =        { path = "../../packages/banking_replicator", version = "0.2.36" }
-cohort_banking  =           { path = "../../packages/cohort_banking", version = "0.2.36" }
-talos_cohort_replicator =   { path = "../../packages/talos_cohort_replicator", version = "0.2.36" }
-talos_certifier =           { path = "../../packages/talos_certifier", version = "0.2.36" }
-talos_certifier_adapters =  { path = "../../packages/talos_certifier_adapters", version = "0.2.36" }
-talos_common_utils =        { path = "../../packages/talos_common_utils", version = "0.2.36" }
-talos_rdkafka_utils =       { path = "../../packages/talos_rdkafka_utils", version = "0.2.36" }
+banking_common =            { path = "../../packages/banking_common", version = "0.2.37-dev" }
+banking_replicator =        { path = "../../packages/banking_replicator", version = "0.2.37-dev" }
+cohort_banking  =           { path = "../../packages/cohort_banking", version = "0.2.37-dev" }
+talos_cohort_replicator =   { path = "../../packages/talos_cohort_replicator", version = "0.2.37-dev" }
+talos_certifier =           { path = "../../packages/talos_certifier", version = "0.2.37-dev" }
+talos_certifier_adapters =  { path = "../../packages/talos_certifier_adapters", version = "0.2.37-dev" }
+talos_common_utils =        { path = "../../packages/talos_common_utils", version = "0.2.37-dev" }
+talos_rdkafka_utils =       { path = "../../packages/talos_rdkafka_utils", version = "0.2.37-dev" }
 
 async-trait = { workspace = true }
 env_logger =  { workspace = true }

--- a/examples/messenger_using_kafka/Cargo.toml
+++ b/examples/messenger_using_kafka/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # [package]
 name = "messenger_using_kafka"
-version = "0.2.36"
+version = "0.2.37-dev"
 edition = "2021"
 keywords = ["talos"]
 description = "Example on consuming `talos_messenger`"
@@ -24,10 +24,10 @@ rdkafka = { version = "0.34.0", features = ["sasl"] }
 ahash = "0.8.3"
 
 # internal crates
-talos_certifier = { path = "../../packages/talos_certifier", version = "0.2.36" }
-talos_suffix = { path = "../../packages/talos_suffix", version = "0.2.36" }
-talos_certifier_adapters = { path = "../../packages/talos_certifier_adapters", version = "0.2.36" }
-talos_common_utils = { path = "../../packages/talos_common_utils", version = "0.2.36" }
-talos_rdkafka_utils = { path = "../../packages/talos_rdkafka_utils", version = "0.2.36" }
-talos_messenger_core = { path = "../../packages/talos_messenger_core", version = "0.2.36" }
-talos_messenger_actions = { path = "../../packages/talos_messenger_actions", version = "0.2.36" }
+talos_certifier = { path = "../../packages/talos_certifier", version = "0.2.37-dev" }
+talos_suffix = { path = "../../packages/talos_suffix", version = "0.2.37-dev" }
+talos_certifier_adapters = { path = "../../packages/talos_certifier_adapters", version = "0.2.37-dev" }
+talos_common_utils = { path = "../../packages/talos_common_utils", version = "0.2.37-dev" }
+talos_rdkafka_utils = { path = "../../packages/talos_rdkafka_utils", version = "0.2.37-dev" }
+talos_messenger_core = { path = "../../packages/talos_messenger_core", version = "0.2.37-dev" }
+talos_messenger_actions = { path = "../../packages/talos_messenger_actions", version = "0.2.37-dev" }

--- a/examples/messenger_using_kafka/Cargo.toml
+++ b/examples/messenger_using_kafka/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # [package]
 name = "messenger_using_kafka"
-version = "0.2.36-dev"
+version = "0.2.36"
 edition = "2021"
 keywords = ["talos"]
 description = "Example on consuming `talos_messenger`"
@@ -24,10 +24,10 @@ rdkafka = { version = "0.34.0", features = ["sasl"] }
 ahash = "0.8.3"
 
 # internal crates
-talos_certifier = { path = "../../packages/talos_certifier", version = "0.2.36-dev" }
-talos_suffix = { path = "../../packages/talos_suffix", version = "0.2.36-dev" }
-talos_certifier_adapters = { path = "../../packages/talos_certifier_adapters", version = "0.2.36-dev" }
-talos_common_utils = { path = "../../packages/talos_common_utils", version = "0.2.36-dev" }
-talos_rdkafka_utils = { path = "../../packages/talos_rdkafka_utils", version = "0.2.36-dev" }
-talos_messenger_core = { path = "../../packages/talos_messenger_core", version = "0.2.36-dev" }
-talos_messenger_actions = { path = "../../packages/talos_messenger_actions", version = "0.2.36-dev" }
+talos_certifier = { path = "../../packages/talos_certifier", version = "0.2.36" }
+talos_suffix = { path = "../../packages/talos_suffix", version = "0.2.36" }
+talos_certifier_adapters = { path = "../../packages/talos_certifier_adapters", version = "0.2.36" }
+talos_common_utils = { path = "../../packages/talos_common_utils", version = "0.2.36" }
+talos_rdkafka_utils = { path = "../../packages/talos_rdkafka_utils", version = "0.2.36" }
+talos_messenger_core = { path = "../../packages/talos_messenger_core", version = "0.2.36" }
+talos_messenger_actions = { path = "../../packages/talos_messenger_actions", version = "0.2.36" }

--- a/examples/messenger_using_kafka/Cargo.toml
+++ b/examples/messenger_using_kafka/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # [package]
 name = "messenger_using_kafka"
-version = "0.2.35"
+version = "0.2.36-dev"
 edition = "2021"
 keywords = ["talos"]
 description = "Example on consuming `talos_messenger`"
@@ -24,10 +24,10 @@ rdkafka = { version = "0.34.0", features = ["sasl"] }
 ahash = "0.8.3"
 
 # internal crates
-talos_certifier = { path = "../../packages/talos_certifier", version = "0.2.35" }
-talos_suffix = { path = "../../packages/talos_suffix", version = "0.2.35" }
-talos_certifier_adapters = { path = "../../packages/talos_certifier_adapters", version = "0.2.35" }
-talos_common_utils = { path = "../../packages/talos_common_utils", version = "0.2.35" }
-talos_rdkafka_utils = { path = "../../packages/talos_rdkafka_utils", version = "0.2.35" }
-talos_messenger_core = { path = "../../packages/talos_messenger_core", version = "0.2.35" }
-talos_messenger_actions = { path = "../../packages/talos_messenger_actions", version = "0.2.35" }
+talos_certifier = { path = "../../packages/talos_certifier", version = "0.2.36-dev" }
+talos_suffix = { path = "../../packages/talos_suffix", version = "0.2.36-dev" }
+talos_certifier_adapters = { path = "../../packages/talos_certifier_adapters", version = "0.2.36-dev" }
+talos_common_utils = { path = "../../packages/talos_common_utils", version = "0.2.36-dev" }
+talos_rdkafka_utils = { path = "../../packages/talos_rdkafka_utils", version = "0.2.36-dev" }
+talos_messenger_core = { path = "../../packages/talos_messenger_core", version = "0.2.36-dev" }
+talos_messenger_actions = { path = "../../packages/talos_messenger_actions", version = "0.2.36-dev" }

--- a/examples/messenger_using_kafka/Cargo.toml
+++ b/examples/messenger_using_kafka/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # [package]
 name = "messenger_using_kafka"
-version = "0.2.35-dev"
+version = "0.2.35"
 edition = "2021"
 keywords = ["talos"]
 description = "Example on consuming `talos_messenger`"
@@ -24,10 +24,10 @@ rdkafka = { version = "0.34.0", features = ["sasl"] }
 ahash = "0.8.3"
 
 # internal crates
-talos_certifier = { path = "../../packages/talos_certifier", version = "0.2.35-dev" }
-talos_suffix = { path = "../../packages/talos_suffix", version = "0.2.35-dev" }
-talos_certifier_adapters = { path = "../../packages/talos_certifier_adapters", version = "0.2.35-dev" }
-talos_common_utils = { path = "../../packages/talos_common_utils", version = "0.2.35-dev" }
-talos_rdkafka_utils = { path = "../../packages/talos_rdkafka_utils", version = "0.2.35-dev" }
-talos_messenger_core = { path = "../../packages/talos_messenger_core", version = "0.2.35-dev" }
-talos_messenger_actions = { path = "../../packages/talos_messenger_actions", version = "0.2.35-dev" }
+talos_certifier = { path = "../../packages/talos_certifier", version = "0.2.35" }
+talos_suffix = { path = "../../packages/talos_suffix", version = "0.2.35" }
+talos_certifier_adapters = { path = "../../packages/talos_certifier_adapters", version = "0.2.35" }
+talos_common_utils = { path = "../../packages/talos_common_utils", version = "0.2.35" }
+talos_rdkafka_utils = { path = "../../packages/talos_rdkafka_utils", version = "0.2.35" }
+talos_messenger_core = { path = "../../packages/talos_messenger_core", version = "0.2.35" }
+talos_messenger_actions = { path = "../../packages/talos_messenger_actions", version = "0.2.35" }

--- a/packages/banking_common/Cargo.toml
+++ b/packages/banking_common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "banking_common"
-version = "0.2.35-dev"
+version = "0.2.35"
 edition = "2021"
 
 [dependencies]
@@ -19,4 +19,4 @@ tokio-postgres =    { version = "0.7", features = [ "with-uuid-1", "with-serde_j
 deadpool =          { version = "0.10.0" }
 deadpool-postgres = { version = "0.11.0" }
 
-talos_common_utils = { path = "../talos_common_utils", version = "0.2.35-dev" }
+talos_common_utils = { path = "../talos_common_utils", version = "0.2.35" }

--- a/packages/banking_common/Cargo.toml
+++ b/packages/banking_common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "banking_common"
-version = "0.2.36"
+version = "0.2.37-dev"
 edition = "2021"
 
 [dependencies]
@@ -19,4 +19,4 @@ tokio-postgres =    { version = "0.7", features = [ "with-uuid-1", "with-serde_j
 deadpool =          { version = "0.10.0" }
 deadpool-postgres = { version = "0.11.0" }
 
-talos_common_utils = { path = "../talos_common_utils", version = "0.2.36" }
+talos_common_utils = { path = "../talos_common_utils", version = "0.2.37-dev" }

--- a/packages/banking_common/Cargo.toml
+++ b/packages/banking_common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "banking_common"
-version = "0.2.36-dev"
+version = "0.2.36"
 edition = "2021"
 
 [dependencies]
@@ -19,4 +19,4 @@ tokio-postgres =    { version = "0.7", features = [ "with-uuid-1", "with-serde_j
 deadpool =          { version = "0.10.0" }
 deadpool-postgres = { version = "0.11.0" }
 
-talos_common_utils = { path = "../talos_common_utils", version = "0.2.36-dev" }
+talos_common_utils = { path = "../talos_common_utils", version = "0.2.36" }

--- a/packages/banking_common/Cargo.toml
+++ b/packages/banking_common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "banking_common"
-version = "0.2.35"
+version = "0.2.36-dev"
 edition = "2021"
 
 [dependencies]
@@ -19,4 +19,4 @@ tokio-postgres =    { version = "0.7", features = [ "with-uuid-1", "with-serde_j
 deadpool =          { version = "0.10.0" }
 deadpool-postgres = { version = "0.11.0" }
 
-talos_common_utils = { path = "../talos_common_utils", version = "0.2.35" }
+talos_common_utils = { path = "../talos_common_utils", version = "0.2.36-dev" }

--- a/packages/banking_replicator/Cargo.toml
+++ b/packages/banking_replicator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "banking_replicator"
-version = "0.2.36-dev"
+version = "0.2.36"
 edition = "2021"
 
 [dependencies]
@@ -25,10 +25,10 @@ opentelemetry =     { version = "0.20.0" }
 strum =             { version = "0.25", features = ["derive"] }
 uuid =              { version = "1.4.1", features = ["v4"] }
 
-banking_common =            { path = "../banking_common", version = "0.2.36-dev" }
-cohort_sdk =                { path = "../cohort_sdk", version = "0.2.36-dev" }
-talos_metrics =             { path = "../talos_metrics", version = "0.2.36-dev" }
-talos_cohort_replicator =   { path = "../talos_cohort_replicator", version = "0.2.36-dev" }
-talos_rdkafka_utils =       { path = "../talos_rdkafka_utils", version = "0.2.36-dev" }
-talos_certifier =           { path = "../talos_certifier", version = "0.2.36-dev" }
-talos_certifier_adapters =  { path = "../talos_certifier_adapters", version = "0.2.36-dev" }
+banking_common =            { path = "../banking_common", version = "0.2.36" }
+cohort_sdk =                { path = "../cohort_sdk", version = "0.2.36" }
+talos_metrics =             { path = "../talos_metrics", version = "0.2.36" }
+talos_cohort_replicator =   { path = "../talos_cohort_replicator", version = "0.2.36" }
+talos_rdkafka_utils =       { path = "../talos_rdkafka_utils", version = "0.2.36" }
+talos_certifier =           { path = "../talos_certifier", version = "0.2.36" }
+talos_certifier_adapters =  { path = "../talos_certifier_adapters", version = "0.2.36" }

--- a/packages/banking_replicator/Cargo.toml
+++ b/packages/banking_replicator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "banking_replicator"
-version = "0.2.35"
+version = "0.2.36-dev"
 edition = "2021"
 
 [dependencies]
@@ -25,10 +25,10 @@ opentelemetry =     { version = "0.20.0" }
 strum =             { version = "0.25", features = ["derive"] }
 uuid =              { version = "1.4.1", features = ["v4"] }
 
-banking_common =            { path = "../banking_common", version = "0.2.35" }
-cohort_sdk =                { path = "../cohort_sdk", version = "0.2.35" }
-talos_metrics =             { path = "../talos_metrics", version = "0.2.35" }
-talos_cohort_replicator =   { path = "../talos_cohort_replicator", version = "0.2.35" }
-talos_rdkafka_utils =       { path = "../talos_rdkafka_utils", version = "0.2.35" }
-talos_certifier =           { path = "../talos_certifier", version = "0.2.35" }
-talos_certifier_adapters =  { path = "../talos_certifier_adapters", version = "0.2.35" }
+banking_common =            { path = "../banking_common", version = "0.2.36-dev" }
+cohort_sdk =                { path = "../cohort_sdk", version = "0.2.36-dev" }
+talos_metrics =             { path = "../talos_metrics", version = "0.2.36-dev" }
+talos_cohort_replicator =   { path = "../talos_cohort_replicator", version = "0.2.36-dev" }
+talos_rdkafka_utils =       { path = "../talos_rdkafka_utils", version = "0.2.36-dev" }
+talos_certifier =           { path = "../talos_certifier", version = "0.2.36-dev" }
+talos_certifier_adapters =  { path = "../talos_certifier_adapters", version = "0.2.36-dev" }

--- a/packages/banking_replicator/Cargo.toml
+++ b/packages/banking_replicator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "banking_replicator"
-version = "0.2.35-dev"
+version = "0.2.35"
 edition = "2021"
 
 [dependencies]
@@ -25,10 +25,10 @@ opentelemetry =     { version = "0.20.0" }
 strum =             { version = "0.25", features = ["derive"] }
 uuid =              { version = "1.4.1", features = ["v4"] }
 
-banking_common =            { path = "../banking_common", version = "0.2.35-dev" }
-cohort_sdk =                { path = "../cohort_sdk", version = "0.2.35-dev" }
-talos_metrics =             { path = "../talos_metrics", version = "0.2.35-dev" }
-talos_cohort_replicator =   { path = "../talos_cohort_replicator", version = "0.2.35-dev" }
-talos_rdkafka_utils =       { path = "../talos_rdkafka_utils", version = "0.2.35-dev" }
-talos_certifier =           { path = "../talos_certifier", version = "0.2.35-dev" }
-talos_certifier_adapters =  { path = "../talos_certifier_adapters", version = "0.2.35-dev" }
+banking_common =            { path = "../banking_common", version = "0.2.35" }
+cohort_sdk =                { path = "../cohort_sdk", version = "0.2.35" }
+talos_metrics =             { path = "../talos_metrics", version = "0.2.35" }
+talos_cohort_replicator =   { path = "../talos_cohort_replicator", version = "0.2.35" }
+talos_rdkafka_utils =       { path = "../talos_rdkafka_utils", version = "0.2.35" }
+talos_certifier =           { path = "../talos_certifier", version = "0.2.35" }
+talos_certifier_adapters =  { path = "../talos_certifier_adapters", version = "0.2.35" }

--- a/packages/banking_replicator/Cargo.toml
+++ b/packages/banking_replicator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "banking_replicator"
-version = "0.2.36"
+version = "0.2.37-dev"
 edition = "2021"
 
 [dependencies]
@@ -25,10 +25,10 @@ opentelemetry =     { version = "0.20.0" }
 strum =             { version = "0.25", features = ["derive"] }
 uuid =              { version = "1.4.1", features = ["v4"] }
 
-banking_common =            { path = "../banking_common", version = "0.2.36" }
-cohort_sdk =                { path = "../cohort_sdk", version = "0.2.36" }
-talos_metrics =             { path = "../talos_metrics", version = "0.2.36" }
-talos_cohort_replicator =   { path = "../talos_cohort_replicator", version = "0.2.36" }
-talos_rdkafka_utils =       { path = "../talos_rdkafka_utils", version = "0.2.36" }
-talos_certifier =           { path = "../talos_certifier", version = "0.2.36" }
-talos_certifier_adapters =  { path = "../talos_certifier_adapters", version = "0.2.36" }
+banking_common =            { path = "../banking_common", version = "0.2.37-dev" }
+cohort_sdk =                { path = "../cohort_sdk", version = "0.2.37-dev" }
+talos_metrics =             { path = "../talos_metrics", version = "0.2.37-dev" }
+talos_cohort_replicator =   { path = "../talos_cohort_replicator", version = "0.2.37-dev" }
+talos_rdkafka_utils =       { path = "../talos_rdkafka_utils", version = "0.2.37-dev" }
+talos_certifier =           { path = "../talos_certifier", version = "0.2.37-dev" }
+talos_certifier_adapters =  { path = "../talos_certifier_adapters", version = "0.2.37-dev" }

--- a/packages/cohort_banking/Cargo.toml
+++ b/packages/cohort_banking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cohort_banking"
-version = "0.2.36"
+version = "0.2.37-dev"
 edition = "2021"
 
 [dependencies]
@@ -23,11 +23,11 @@ strum =             { version = "0.25", features = ["derive"] }
 tokio-postgres =    { version = "0.7", features = [ "with-uuid-1", "with-serde_json-1" ] }
 uuid =              { version = "1.4.1", features = ["v4"] }
 
-cohort_sdk =                 { path = "../cohort_sdk", version = "0.2.36" }
-banking_common =             { path = "../banking_common", version = "0.2.36" }
-talos_agent =                { path = "../talos_agent", version = "0.2.36" }
-talos_metrics =              { path = "../talos_metrics", version = "0.2.36" }
-talos_certifier =            { path = "../talos_certifier", version = "0.2.36" }
-talos_cohort_replicator =    { path = "../talos_cohort_replicator", version = "0.2.36" }
-talos_common_utils =         { path = "../talos_common_utils", version = "0.2.36" }
-talos_suffix =               { path = "../talos_suffix", version = "0.2.36" }
+cohort_sdk =                 { path = "../cohort_sdk", version = "0.2.37-dev" }
+banking_common =             { path = "../banking_common", version = "0.2.37-dev" }
+talos_agent =                { path = "../talos_agent", version = "0.2.37-dev" }
+talos_metrics =              { path = "../talos_metrics", version = "0.2.37-dev" }
+talos_certifier =            { path = "../talos_certifier", version = "0.2.37-dev" }
+talos_cohort_replicator =    { path = "../talos_cohort_replicator", version = "0.2.37-dev" }
+talos_common_utils =         { path = "../talos_common_utils", version = "0.2.37-dev" }
+talos_suffix =               { path = "../talos_suffix", version = "0.2.37-dev" }

--- a/packages/cohort_banking/Cargo.toml
+++ b/packages/cohort_banking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cohort_banking"
-version = "0.2.35-dev"
+version = "0.2.35"
 edition = "2021"
 
 [dependencies]
@@ -23,11 +23,11 @@ strum =             { version = "0.25", features = ["derive"] }
 tokio-postgres =    { version = "0.7", features = [ "with-uuid-1", "with-serde_json-1" ] }
 uuid =              { version = "1.4.1", features = ["v4"] }
 
-cohort_sdk =                 { path = "../cohort_sdk", version = "0.2.35-dev" }
-banking_common =             { path = "../banking_common", version = "0.2.35-dev" }
-talos_agent =                { path = "../talos_agent", version = "0.2.35-dev" }
-talos_metrics =              { path = "../talos_metrics", version = "0.2.35-dev" }
-talos_certifier =            { path = "../talos_certifier", version = "0.2.35-dev" }
-talos_cohort_replicator =    { path = "../talos_cohort_replicator", version = "0.2.35-dev" }
-talos_common_utils =         { path = "../talos_common_utils", version = "0.2.35-dev" }
-talos_suffix =               { path = "../talos_suffix", version = "0.2.35-dev" }
+cohort_sdk =                 { path = "../cohort_sdk", version = "0.2.35" }
+banking_common =             { path = "../banking_common", version = "0.2.35" }
+talos_agent =                { path = "../talos_agent", version = "0.2.35" }
+talos_metrics =              { path = "../talos_metrics", version = "0.2.35" }
+talos_certifier =            { path = "../talos_certifier", version = "0.2.35" }
+talos_cohort_replicator =    { path = "../talos_cohort_replicator", version = "0.2.35" }
+talos_common_utils =         { path = "../talos_common_utils", version = "0.2.35" }
+talos_suffix =               { path = "../talos_suffix", version = "0.2.35" }

--- a/packages/cohort_banking/Cargo.toml
+++ b/packages/cohort_banking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cohort_banking"
-version = "0.2.36-dev"
+version = "0.2.36"
 edition = "2021"
 
 [dependencies]
@@ -23,11 +23,11 @@ strum =             { version = "0.25", features = ["derive"] }
 tokio-postgres =    { version = "0.7", features = [ "with-uuid-1", "with-serde_json-1" ] }
 uuid =              { version = "1.4.1", features = ["v4"] }
 
-cohort_sdk =                 { path = "../cohort_sdk", version = "0.2.36-dev" }
-banking_common =             { path = "../banking_common", version = "0.2.36-dev" }
-talos_agent =                { path = "../talos_agent", version = "0.2.36-dev" }
-talos_metrics =              { path = "../talos_metrics", version = "0.2.36-dev" }
-talos_certifier =            { path = "../talos_certifier", version = "0.2.36-dev" }
-talos_cohort_replicator =    { path = "../talos_cohort_replicator", version = "0.2.36-dev" }
-talos_common_utils =         { path = "../talos_common_utils", version = "0.2.36-dev" }
-talos_suffix =               { path = "../talos_suffix", version = "0.2.36-dev" }
+cohort_sdk =                 { path = "../cohort_sdk", version = "0.2.36" }
+banking_common =             { path = "../banking_common", version = "0.2.36" }
+talos_agent =                { path = "../talos_agent", version = "0.2.36" }
+talos_metrics =              { path = "../talos_metrics", version = "0.2.36" }
+talos_certifier =            { path = "../talos_certifier", version = "0.2.36" }
+talos_cohort_replicator =    { path = "../talos_cohort_replicator", version = "0.2.36" }
+talos_common_utils =         { path = "../talos_common_utils", version = "0.2.36" }
+talos_suffix =               { path = "../talos_suffix", version = "0.2.36" }

--- a/packages/cohort_banking/Cargo.toml
+++ b/packages/cohort_banking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cohort_banking"
-version = "0.2.35"
+version = "0.2.36-dev"
 edition = "2021"
 
 [dependencies]
@@ -23,11 +23,11 @@ strum =             { version = "0.25", features = ["derive"] }
 tokio-postgres =    { version = "0.7", features = [ "with-uuid-1", "with-serde_json-1" ] }
 uuid =              { version = "1.4.1", features = ["v4"] }
 
-cohort_sdk =                 { path = "../cohort_sdk", version = "0.2.35" }
-banking_common =             { path = "../banking_common", version = "0.2.35" }
-talos_agent =                { path = "../talos_agent", version = "0.2.35" }
-talos_metrics =              { path = "../talos_metrics", version = "0.2.35" }
-talos_certifier =            { path = "../talos_certifier", version = "0.2.35" }
-talos_cohort_replicator =    { path = "../talos_cohort_replicator", version = "0.2.35" }
-talos_common_utils =         { path = "../talos_common_utils", version = "0.2.35" }
-talos_suffix =               { path = "../talos_suffix", version = "0.2.35" }
+cohort_sdk =                 { path = "../cohort_sdk", version = "0.2.36-dev" }
+banking_common =             { path = "../banking_common", version = "0.2.36-dev" }
+talos_agent =                { path = "../talos_agent", version = "0.2.36-dev" }
+talos_metrics =              { path = "../talos_metrics", version = "0.2.36-dev" }
+talos_certifier =            { path = "../talos_certifier", version = "0.2.36-dev" }
+talos_cohort_replicator =    { path = "../talos_cohort_replicator", version = "0.2.36-dev" }
+talos_common_utils =         { path = "../talos_common_utils", version = "0.2.36-dev" }
+talos_suffix =               { path = "../talos_suffix", version = "0.2.36-dev" }

--- a/packages/cohort_banking/src/app.rs
+++ b/packages/cohort_banking/src/app.rs
@@ -123,7 +123,7 @@ impl Handler<TransferRequest> for BankingApp {
             .cohort_api
             .as_ref()
             .expect("Banking app is not initialised")
-            .certify(&request_payload_callback, &oo_inst)
+            .certify(&request_payload_callback, &oo_inst, None)
             .await
         {
             Ok(rsp) => {

--- a/packages/cohort_sdk/Cargo.toml
+++ b/packages/cohort_sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cohort_sdk"
-version = "0.2.35"
+version = "0.2.36-dev"
 edition = "2021"
 
 [dependencies]
@@ -34,11 +34,11 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 strum = { version = "0.27.1", features = ["derive"] }
 time = { version = "0.3.29" }
-talos_metrics =             { path = "../talos_metrics", version = "0.2.35" }
-talos_agent =               { path = "../talos_agent", version = "0.2.35" }
-talos_certifier =           { path = "../talos_certifier", version = "0.2.35" }
-talos_cohort_replicator =   { path = "../talos_cohort_replicator", version = "0.2.35" }
-talos_rdkafka_utils =       { path = "../talos_rdkafka_utils", version = "0.2.35" }
+talos_metrics =             { path = "../talos_metrics", version = "0.2.36-dev" }
+talos_agent =               { path = "../talos_agent", version = "0.2.36-dev" }
+talos_certifier =           { path = "../talos_certifier", version = "0.2.36-dev" }
+talos_cohort_replicator =   { path = "../talos_cohort_replicator", version = "0.2.36-dev" }
+talos_rdkafka_utils =       { path = "../talos_rdkafka_utils", version = "0.2.36-dev" }
 uuid =                      { version = "1.4.1", features = ["v4"] }
 
 tokio = { workspace = true, features = ["full"] }

--- a/packages/cohort_sdk/Cargo.toml
+++ b/packages/cohort_sdk/Cargo.toml
@@ -4,22 +4,36 @@ version = "0.2.35-dev"
 edition = "2021"
 
 [dependencies]
-
 async-trait = { workspace = true }
-env_logger = { workspace = true }
-log = { workspace = true }
 futures = { version = "0.3.28" }
-opentelemetry_api = { version = "0.20.0" }
-opentelemetry_sdk = { version = "0.20.0", features = ["metrics", "rt-tokio"] }
-opentelemetry = { version = "0.20.0" }
-rand = { version = "0.8.5" }
 
-rdkafka = { version = "0.34.0", features = ["sasl"]  }
+# Tracing dependencies
+#   We will move telemetry dependencies to the workspace once we adapt all projects. Currenly only SDK uses them.
+
+#   For OTEL exporter over 'GRPC' protocol
+axum =                      { version = "0.7" } # 0.7 is intentionally pinned
+tonic =                     { version = "0.12.3" }
+
+opentelemetry =             { version = "0.28.0", default-features = false, features = ["trace"]  }
+opentelemetry_sdk =         { version = "0.28.0", default-features = false, features = ["trace", "rt-tokio"] }
+opentelemetry-otlp =        { version = "0.28.0", features = [ "trace", "grpc-tonic" ] }
+opentelemetry-stdout =      { version = "0.28.0", features = [ "trace" ] }
+tracing =                   { version = "0.1.41", features = [ "log" ] }
+tracing-opentelemetry =     { version = "0.29.0" }
+tracing-bunyan-formatter =  { version = "0.3.10" }
+tracing-subscriber =        { version = "0.3.19", features = [ "fmt", "ansi", "json", "registry", "env-filter" ] }
+# The end of tracing dependencies
+
+thiserror = { version = "2.0.11" }
+
+rand = { version = "0.9.0" }
+
+rdkafka = { version = "0.37.0", features = ["sasl"]  }
 
 serde = { workspace = true }
 serde_json = { workspace = true }
-strum = { version = "0.25", features = ["derive"] }
-time = { version = "0.3.17" }
+strum = { version = "0.27.1", features = ["derive"] }
+time = { version = "0.3.29" }
 talos_metrics =             { path = "../talos_metrics", version = "0.2.35-dev" }
 talos_agent =               { path = "../talos_agent", version = "0.2.35-dev" }
 talos_certifier =           { path = "../talos_certifier", version = "0.2.35-dev" }

--- a/packages/cohort_sdk/Cargo.toml
+++ b/packages/cohort_sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cohort_sdk"
-version = "0.2.36-dev"
+version = "0.2.36"
 edition = "2021"
 
 [dependencies]
@@ -34,11 +34,11 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 strum = { version = "0.27.1", features = ["derive"] }
 time = { version = "0.3.29" }
-talos_metrics =             { path = "../talos_metrics", version = "0.2.36-dev" }
-talos_agent =               { path = "../talos_agent", version = "0.2.36-dev" }
-talos_certifier =           { path = "../talos_certifier", version = "0.2.36-dev" }
-talos_cohort_replicator =   { path = "../talos_cohort_replicator", version = "0.2.36-dev" }
-talos_rdkafka_utils =       { path = "../talos_rdkafka_utils", version = "0.2.36-dev" }
+talos_metrics =             { path = "../talos_metrics", version = "0.2.36" }
+talos_agent =               { path = "../talos_agent", version = "0.2.36" }
+talos_certifier =           { path = "../talos_certifier", version = "0.2.36" }
+talos_cohort_replicator =   { path = "../talos_cohort_replicator", version = "0.2.36" }
+talos_rdkafka_utils =       { path = "../talos_rdkafka_utils", version = "0.2.36" }
 uuid =                      { version = "1.4.1", features = ["v4"] }
 
 tokio = { workspace = true, features = ["full"] }

--- a/packages/cohort_sdk/Cargo.toml
+++ b/packages/cohort_sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cohort_sdk"
-version = "0.2.35-dev"
+version = "0.2.35"
 edition = "2021"
 
 [dependencies]
@@ -34,11 +34,11 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 strum = { version = "0.27.1", features = ["derive"] }
 time = { version = "0.3.29" }
-talos_metrics =             { path = "../talos_metrics", version = "0.2.35-dev" }
-talos_agent =               { path = "../talos_agent", version = "0.2.35-dev" }
-talos_certifier =           { path = "../talos_certifier", version = "0.2.35-dev" }
-talos_cohort_replicator =   { path = "../talos_cohort_replicator", version = "0.2.35-dev" }
-talos_rdkafka_utils =       { path = "../talos_rdkafka_utils", version = "0.2.35-dev" }
+talos_metrics =             { path = "../talos_metrics", version = "0.2.35" }
+talos_agent =               { path = "../talos_agent", version = "0.2.35" }
+talos_certifier =           { path = "../talos_certifier", version = "0.2.35" }
+talos_cohort_replicator =   { path = "../talos_cohort_replicator", version = "0.2.35" }
+talos_rdkafka_utils =       { path = "../talos_rdkafka_utils", version = "0.2.35" }
 uuid =                      { version = "1.4.1", features = ["v4"] }
 
 tokio = { workspace = true, features = ["full"] }

--- a/packages/cohort_sdk/Cargo.toml
+++ b/packages/cohort_sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cohort_sdk"
-version = "0.2.36"
+version = "0.2.37-dev"
 edition = "2021"
 
 [dependencies]
@@ -34,11 +34,11 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 strum = { version = "0.27.1", features = ["derive"] }
 time = { version = "0.3.29" }
-talos_metrics =             { path = "../talos_metrics", version = "0.2.36" }
-talos_agent =               { path = "../talos_agent", version = "0.2.36" }
-talos_certifier =           { path = "../talos_certifier", version = "0.2.36" }
-talos_cohort_replicator =   { path = "../talos_cohort_replicator", version = "0.2.36" }
-talos_rdkafka_utils =       { path = "../talos_rdkafka_utils", version = "0.2.36" }
+talos_metrics =             { path = "../talos_metrics", version = "0.2.37-dev" }
+talos_agent =               { path = "../talos_agent", version = "0.2.37-dev" }
+talos_certifier =           { path = "../talos_certifier", version = "0.2.37-dev" }
+talos_cohort_replicator =   { path = "../talos_cohort_replicator", version = "0.2.37-dev" }
+talos_rdkafka_utils =       { path = "../talos_rdkafka_utils", version = "0.2.37-dev" }
 uuid =                      { version = "1.4.1", features = ["v4"] }
 
 tokio = { workspace = true, features = ["full"] }

--- a/packages/cohort_sdk/src/delay_controller.rs
+++ b/packages/cohort_sdk/src/delay_controller.rs
@@ -35,8 +35,8 @@ impl DelayController {
         self.multiplier *= 2;
 
         let add = {
-            let mut rnd = rand::thread_rng();
-            rnd.gen_range(m..=m * 2)
+            let mut rnd = rand::rng();
+            rnd.random_range(m..=m * 2)
         };
 
         let delay_ms = std::cmp::min(self.max_sleep_ms, m + add);

--- a/packages/cohort_sdk/src/lib.rs
+++ b/packages/cohort_sdk/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod cohort;
 pub mod delay_controller;
 pub mod model;
+pub mod otel;

--- a/packages/cohort_sdk/src/model/mod.rs
+++ b/packages/cohort_sdk/src/model/mod.rs
@@ -90,6 +90,18 @@ pub struct Config {
     // Kafka configs for Agent
     //
     pub kafka: KafkaConfig,
+
+    //
+    // OTEL config
+    //
+    pub otel_telemetry: CohortOtelConfig,
+}
+
+#[derive(Clone, Default)]
+pub struct CohortOtelConfig {
+    pub enabled: bool,
+    // The endpoint to OTEL collector
+    pub grpc_endpoint: Option<String>,
 }
 
 impl Config {
@@ -108,6 +120,7 @@ impl Config {
 
             // Kafka
             kafka: kafka_config,
+            otel_telemetry: CohortOtelConfig::default(),
         }
     }
 }

--- a/packages/cohort_sdk/src/otel/initialiser.rs
+++ b/packages/cohort_sdk/src/otel/initialiser.rs
@@ -1,0 +1,97 @@
+use opentelemetry::trace::{TraceError, TracerProvider as _};
+use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::propagation::TraceContextPropagator;
+use strum::Display;
+use thiserror::Error as ThisError;
+use tracing::subscriber::{set_global_default, SetGlobalDefaultError};
+use tracing_bunyan_formatter::{BunyanFormattingLayer, JsonStorageLayer};
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::{fmt, EnvFilter};
+
+use crate::model::ClientError;
+
+pub fn init_otel(name: String, enable_tracing: bool, grpc_endpoint: Option<String>, default_level: &'static str) -> Result<(), OtelInitError> {
+    let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_level));
+
+    let layer_fmt = fmt::Layer::new().json();
+
+    if !enable_tracing {
+        // setup only logging
+
+        let subscriber = tracing_subscriber::registry().with(layer_fmt).with(env_filter);
+
+        set_global_default(subscriber).map_err(OtelInitError::from_global_subscriber_error)?;
+        return Ok(());
+    }
+
+    opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
+
+    if let Some(grpc_endpoint) = grpc_endpoint {
+        let otel_exporter = opentelemetry_otlp::SpanExporter::builder()
+            .with_tonic()
+            .with_endpoint(grpc_endpoint)
+            .with_protocol(opentelemetry_otlp::Protocol::Grpc)
+            .build()
+            .map_err(OtelInitError::from_exporter_error)?;
+
+        let otlp_trace_provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
+            .with_batch_exporter(otel_exporter)
+            .build();
+
+        let otlp_layer = tracing_opentelemetry::layer().with_tracer(otlp_trace_provider.tracer(name.clone()));
+        let subscriber = tracing_subscriber::registry().with(layer_fmt).with(env_filter).with(otlp_layer);
+
+        set_global_default(subscriber).map_err(OtelInitError::from_global_subscriber_error)?;
+    } else {
+        let layer_fmt = BunyanFormattingLayer::new(name.clone(), std::io::stdout);
+        let subscriber = tracing_subscriber::registry().with(env_filter).with(JsonStorageLayer).with(layer_fmt);
+
+        set_global_default(subscriber).map_err(OtelInitError::from_global_subscriber_error)?;
+    }
+
+    tracing::info!("OTEL has been initialised");
+
+    Ok(())
+}
+
+#[derive(Debug, ThisError)]
+#[error("Error initialising OTEL telemetry: '{kind}'.\nReason: {reason}\nCause: {cause:?}")]
+pub struct OtelInitError {
+    pub kind: InitErrorType,
+    pub reason: String,
+    pub cause: Option<String>,
+}
+
+impl OtelInitError {
+    pub fn from_global_subscriber_error(cause: SetGlobalDefaultError) -> Self {
+        OtelInitError {
+            kind: InitErrorType::GlobalScubscriberError,
+            reason: "Unable to set subscriber into global OTEL registry".into(),
+            cause: Some(cause.to_string()),
+        }
+    }
+
+    pub fn from_exporter_error(cause: TraceError) -> Self {
+        OtelInitError {
+            kind: InitErrorType::SpanExporter,
+            reason: "Unable to initialise OTEL exporter".into(),
+            cause: Some(cause.to_string()),
+        }
+    }
+}
+
+#[derive(Debug, Display, PartialEq, Clone)]
+pub enum InitErrorType {
+    GlobalScubscriberError,
+    SpanExporter,
+}
+
+impl From<OtelInitError> for ClientError {
+    fn from(value: OtelInitError) -> Self {
+        Self {
+            kind: crate::model::ClientErrorKind::Internal,
+            cause: Some(value.to_string()),
+            reason: "Error initialising OTEL".into(),
+        }
+    }
+}

--- a/packages/cohort_sdk/src/otel/meters.rs
+++ b/packages/cohort_sdk/src/otel/meters.rs
@@ -1,0 +1,131 @@
+use std::sync::Arc;
+
+use opentelemetry::{
+    global,
+    metrics::{Counter, Histogram},
+};
+
+pub struct CohortMeters {
+    oo_retry_counter: Arc<Counter<u64>>,
+    oo_giveups_counter: Arc<Counter<u64>>,
+    oo_not_safe_counter: Arc<Counter<u64>>,
+    oo_install_histogram: Arc<Histogram<f64>>,
+    oo_attempts_histogram: Arc<Histogram<u64>>,
+    oo_install_and_wait_histogram: Arc<Histogram<f64>>,
+    oo_wait_histogram: Arc<Histogram<f64>>,
+    talos_histogram: Arc<Histogram<f64>>,
+    talos_aborts_counter: Arc<Counter<u64>>,
+    agent_retries_histogram: Arc<Histogram<u64>>,
+    agent_errors_counter: Arc<Counter<u64>>,
+    db_errors_counter: Arc<Counter<u64>>,
+}
+
+impl Default for CohortMeters {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CohortMeters {
+    pub fn new() -> CohortMeters {
+        let meter = global::meter("cohort_sdk");
+        let oo_install_histogram = meter.f64_histogram("metric_oo_install_duration").with_unit("ms").build();
+        let oo_attempts_histogram = meter.u64_histogram("metric_oo_attempts").with_unit("tx").build();
+        let oo_install_and_wait_histogram = meter.f64_histogram("metric_oo_install_and_wait_duration").with_unit("ms").build();
+        let oo_wait_histogram = meter.f64_histogram("metric_oo_wait_duration").with_unit("ms").build();
+        let talos_histogram = meter.f64_histogram("metric_talos").with_unit("ms").build();
+        let oo_retry_counter = meter.u64_counter("metric_oo_retry_count").with_unit("tx").build();
+        let oo_giveups_counter = meter.u64_counter("metric_oo_giveups_count").with_unit("tx").build();
+        let oo_not_safe_counter = meter.u64_counter("metric_oo_not_safe_count").with_unit("tx").build();
+        let talos_aborts_counter = meter.u64_counter("metric_talos_aborts_count").with_unit("tx").build();
+        let agent_errors_counter = meter.u64_counter("metric_agent_errors_count").with_unit("tx").build();
+        let agent_retries_histogram = meter.u64_histogram("metric_agent_retries").with_unit("tx").build();
+        let db_errors_counter = meter.u64_counter("metric_db_errors_count").with_unit("tx").build();
+
+        oo_retry_counter.add(0, &[]);
+        oo_giveups_counter.add(0, &[]);
+        oo_not_safe_counter.add(0, &[]);
+        talos_aborts_counter.add(0, &[]);
+        agent_errors_counter.add(0, &[]);
+        db_errors_counter.add(0, &[]);
+
+        Self {
+            oo_install_histogram: Arc::new(oo_install_histogram),
+            oo_install_and_wait_histogram: Arc::new(oo_install_and_wait_histogram),
+            oo_wait_histogram: Arc::new(oo_wait_histogram),
+            oo_retry_counter: Arc::new(oo_retry_counter),
+            oo_giveups_counter: Arc::new(oo_giveups_counter),
+            oo_not_safe_counter: Arc::new(oo_not_safe_counter),
+            oo_attempts_histogram: Arc::new(oo_attempts_histogram),
+            talos_histogram: Arc::new(talos_histogram),
+            agent_retries_histogram: Arc::new(agent_retries_histogram),
+            talos_aborts_counter: Arc::new(talos_aborts_counter),
+            agent_errors_counter: Arc::new(agent_errors_counter),
+            db_errors_counter: Arc::new(db_errors_counter),
+        }
+    }
+
+    pub fn update_talos_metric(&self, value: f64) {
+        let hist = Arc::clone(&self.talos_histogram);
+        tokio::spawn(async move {
+            hist.record(value, &[]);
+        });
+    }
+
+    pub fn update_oo_install_metric(&self, value: f64) {
+        let hist = Arc::clone(&self.oo_install_histogram);
+        tokio::spawn(async move {
+            hist.record(value, &[]);
+        });
+    }
+
+    pub fn update_post_oo_install_metrics(
+        &self,
+        number_of_not_save_responses: u64,
+        total_sleep: u128,
+        number_of_giveups: u64,
+        number_of_attempts: u32,
+        duration: f64,
+    ) {
+        let c_not_safe = Arc::clone(&self.oo_not_safe_counter);
+        let h_total_sleep = Arc::clone(&self.oo_wait_histogram);
+        let h_attempts = Arc::clone(&self.oo_attempts_histogram);
+        let h_span_2 = Arc::clone(&self.oo_install_and_wait_histogram);
+        let c_giveups = Arc::clone(&self.oo_giveups_counter);
+        let c_retry = Arc::clone(&self.oo_retry_counter);
+
+        tokio::spawn(async move {
+            if number_of_not_save_responses > 0 {
+                c_not_safe.add(number_of_not_save_responses, &[]);
+            }
+            if total_sleep > 0 {
+                h_total_sleep.record(total_sleep as f64 * 100.0, &[]);
+            }
+            if number_of_giveups > 0 {
+                c_giveups.add(number_of_giveups, &[]);
+            }
+            if number_of_attempts > 1 {
+                c_retry.add(number_of_attempts as u64 - 1, &[]);
+            }
+
+            h_attempts.record(number_of_attempts as u64, &[]);
+            h_span_2.record(duration * 100.0, &[]);
+        });
+    }
+
+    pub fn update_post_send_to_talos_metrics(&self, agent_errors: u64, db_errors: u64, talos_aborts: u64, attempts: u32) {
+        let c_talos_aborts = Arc::clone(&self.talos_aborts_counter);
+        let c_agent_errors = Arc::clone(&self.agent_errors_counter);
+        let c_db_errors = Arc::clone(&self.db_errors_counter);
+        let h_agent_retries = Arc::clone(&self.agent_retries_histogram);
+
+        if agent_errors > 0 || db_errors > 0 || talos_aborts > 0 || attempts > 0 {
+            tokio::spawn(async move {
+                c_talos_aborts.add(talos_aborts, &[]);
+                c_agent_errors.add(agent_errors, &[]);
+                c_db_errors.add(db_errors, &[]);
+                h_agent_retries.record(attempts as u64, &[]);
+            });
+        }
+    }
+}

--- a/packages/cohort_sdk/src/otel/mod.rs
+++ b/packages/cohort_sdk/src/otel/mod.rs
@@ -1,0 +1,2 @@
+pub mod initialiser;
+pub mod meters;

--- a/packages/cohort_sdk_js/Cargo.toml
+++ b/packages/cohort_sdk_js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cohort_sdk_js"
-version = "0.2.35-dev"
+version = "0.2.35"
 edition = "2021"
 
 [lib]
@@ -30,11 +30,11 @@ chrono = { version = "0.4.19", features = ["serde"] }
 
 tokio = { workspace = true, features = ["full"] }
 
-cohort_sdk = { path = "../cohort_sdk", version = "0.2.35-dev" }
-talos_agent = { path = "../talos_agent", version = "0.2.35-dev" }
-talos_cohort_replicator = { path = "../talos_cohort_replicator", version = "0.2.35-dev" }
-talos_certifier = { path = "../talos_certifier", version = "0.2.35-dev" }
-talos_certifier_adapters = { path = "../talos_certifier_adapters", version = "0.2.35-dev" }
-talos_rdkafka_utils = { path = "../talos_rdkafka_utils", version = "0.2.35-dev" }
+cohort_sdk = { path = "../cohort_sdk", version = "0.2.35" }
+talos_agent = { path = "../talos_agent", version = "0.2.35" }
+talos_cohort_replicator = { path = "../talos_cohort_replicator", version = "0.2.35" }
+talos_certifier = { path = "../talos_certifier", version = "0.2.35" }
+talos_certifier_adapters = { path = "../talos_certifier_adapters", version = "0.2.35" }
+talos_rdkafka_utils = { path = "../talos_rdkafka_utils", version = "0.2.35" }
 
 async-trait = "0.1.72"

--- a/packages/cohort_sdk_js/Cargo.toml
+++ b/packages/cohort_sdk_js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cohort_sdk_js"
-version = "0.2.36-dev"
+version = "0.2.36"
 edition = "2021"
 
 [lib]
@@ -30,11 +30,11 @@ chrono = { version = "0.4.19", features = ["serde"] }
 
 tokio = { workspace = true, features = ["full"] }
 
-cohort_sdk = { path = "../cohort_sdk", version = "0.2.36-dev" }
-talos_agent = { path = "../talos_agent", version = "0.2.36-dev" }
-talos_cohort_replicator = { path = "../talos_cohort_replicator", version = "0.2.36-dev" }
-talos_certifier = { path = "../talos_certifier", version = "0.2.36-dev" }
-talos_certifier_adapters = { path = "../talos_certifier_adapters", version = "0.2.36-dev" }
-talos_rdkafka_utils = { path = "../talos_rdkafka_utils", version = "0.2.36-dev" }
+cohort_sdk = { path = "../cohort_sdk", version = "0.2.36" }
+talos_agent = { path = "../talos_agent", version = "0.2.36" }
+talos_cohort_replicator = { path = "../talos_cohort_replicator", version = "0.2.36" }
+talos_certifier = { path = "../talos_certifier", version = "0.2.36" }
+talos_certifier_adapters = { path = "../talos_certifier_adapters", version = "0.2.36" }
+talos_rdkafka_utils = { path = "../talos_rdkafka_utils", version = "0.2.36" }
 
 async-trait = "0.1.72"

--- a/packages/cohort_sdk_js/Cargo.toml
+++ b/packages/cohort_sdk_js/Cargo.toml
@@ -3,7 +3,6 @@ name = "cohort_sdk_js"
 version = "0.2.35-dev"
 edition = "2021"
 
-
 [lib]
 crate-type = ["cdylib"]
 
@@ -19,21 +18,14 @@ napi = { version = "2.10.3", features = [
     "chrono_date",
     "serde-json",
 ] }
-napi-build = "=2.1.3"
-zerofrom = { version = "=0.1.5" }
-litemap = { version = "=0.7.4" }
+napi-build = "=2.1.3" # pinned to use rustc 75
 napi-derive = "2.9.3"
-thiserror = "1.0"
+thiserror = "2.0.11"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 uuid = { version = "1.4.1", features = ["v4", "serde"] }
 chrono = { version = "0.4.19", features = ["serde"] }
 
-# db migrations
-#refinery = {version="0.8", features=["tokio-postgres"]}
-# crate depencies
-env_logger = { workspace = true }
-log = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 
 cohort_sdk = { path = "../cohort_sdk", version = "0.2.35-dev" }
@@ -44,8 +36,3 @@ talos_certifier_adapters = { path = "../talos_certifier_adapters", version = "0.
 talos_rdkafka_utils = { path = "../talos_rdkafka_utils", version = "0.2.35-dev" }
 
 async-trait = "0.1.72"
-
-#[dev-dependencies.cargo-husky]
-#version = "1"
-#default-features = false # Disable features which are enabled by default
-#features = ["user-hooks"]

--- a/packages/cohort_sdk_js/Cargo.toml
+++ b/packages/cohort_sdk_js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cohort_sdk_js"
-version = "0.2.35"
+version = "0.2.36-dev"
 edition = "2021"
 
 [lib]
@@ -30,11 +30,11 @@ chrono = { version = "0.4.19", features = ["serde"] }
 
 tokio = { workspace = true, features = ["full"] }
 
-cohort_sdk = { path = "../cohort_sdk", version = "0.2.35" }
-talos_agent = { path = "../talos_agent", version = "0.2.35" }
-talos_cohort_replicator = { path = "../talos_cohort_replicator", version = "0.2.35" }
-talos_certifier = { path = "../talos_certifier", version = "0.2.35" }
-talos_certifier_adapters = { path = "../talos_certifier_adapters", version = "0.2.35" }
-talos_rdkafka_utils = { path = "../talos_rdkafka_utils", version = "0.2.35" }
+cohort_sdk = { path = "../cohort_sdk", version = "0.2.36-dev" }
+talos_agent = { path = "../talos_agent", version = "0.2.36-dev" }
+talos_cohort_replicator = { path = "../talos_cohort_replicator", version = "0.2.36-dev" }
+talos_certifier = { path = "../talos_certifier", version = "0.2.36-dev" }
+talos_certifier_adapters = { path = "../talos_certifier_adapters", version = "0.2.36-dev" }
+talos_rdkafka_utils = { path = "../talos_rdkafka_utils", version = "0.2.36-dev" }
 
 async-trait = "0.1.72"

--- a/packages/cohort_sdk_js/Cargo.toml
+++ b/packages/cohort_sdk_js/Cargo.toml
@@ -19,6 +19,8 @@ napi = { version = "2.10.3", features = [
     "serde-json",
 ] }
 napi-build = "=2.1.3" # pinned to use rustc 75
+zerofrom = { version = "=0.1.5" }
+litemap = { version = "=0.7.4" }
 napi-derive = "2.9.3"
 thiserror = "2.0.11"
 serde = { version = "1.0", features = ["derive"] }

--- a/packages/cohort_sdk_js/Cargo.toml
+++ b/packages/cohort_sdk_js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cohort_sdk_js"
-version = "0.2.36"
+version = "0.2.37-dev"
 edition = "2021"
 
 [lib]
@@ -30,11 +30,11 @@ chrono = { version = "0.4.19", features = ["serde"] }
 
 tokio = { workspace = true, features = ["full"] }
 
-cohort_sdk = { path = "../cohort_sdk", version = "0.2.36" }
-talos_agent = { path = "../talos_agent", version = "0.2.36" }
-talos_cohort_replicator = { path = "../talos_cohort_replicator", version = "0.2.36" }
-talos_certifier = { path = "../talos_certifier", version = "0.2.36" }
-talos_certifier_adapters = { path = "../talos_certifier_adapters", version = "0.2.36" }
-talos_rdkafka_utils = { path = "../talos_rdkafka_utils", version = "0.2.36" }
+cohort_sdk = { path = "../cohort_sdk", version = "0.2.37-dev" }
+talos_agent = { path = "../talos_agent", version = "0.2.37-dev" }
+talos_cohort_replicator = { path = "../talos_cohort_replicator", version = "0.2.37-dev" }
+talos_certifier = { path = "../talos_certifier", version = "0.2.37-dev" }
+talos_certifier_adapters = { path = "../talos_certifier_adapters", version = "0.2.37-dev" }
+talos_rdkafka_utils = { path = "../talos_rdkafka_utils", version = "0.2.37-dev" }
 
 async-trait = "0.1.72"

--- a/packages/cohort_sdk_js/npm/darwin-arm64/package.json
+++ b/packages/cohort_sdk_js/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cohort_sdk_js-darwin-arm64",
-  "version": "0.2.35",
+  "version": "0.2.36-dev",
   "os": [
     "darwin"
   ],

--- a/packages/cohort_sdk_js/npm/darwin-arm64/package.json
+++ b/packages/cohort_sdk_js/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cohort_sdk_js-darwin-arm64",
-  "version": "0.2.35-dev",
+  "version": "0.2.35",
   "os": [
     "darwin"
   ],

--- a/packages/cohort_sdk_js/npm/darwin-arm64/package.json
+++ b/packages/cohort_sdk_js/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cohort_sdk_js-darwin-arm64",
-  "version": "0.2.36",
+  "version": "0.2.37-dev",
   "os": [
     "darwin"
   ],

--- a/packages/cohort_sdk_js/npm/darwin-arm64/package.json
+++ b/packages/cohort_sdk_js/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cohort_sdk_js-darwin-arm64",
-  "version": "0.2.36-dev",
+  "version": "0.2.36",
   "os": [
     "darwin"
   ],

--- a/packages/cohort_sdk_js/npm/darwin-universal/package.json
+++ b/packages/cohort_sdk_js/npm/darwin-universal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cohort_sdk_js-darwin-universal",
-  "version": "0.2.36-dev",
+  "version": "0.2.36",
   "os": [
     "darwin"
   ],

--- a/packages/cohort_sdk_js/npm/darwin-universal/package.json
+++ b/packages/cohort_sdk_js/npm/darwin-universal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cohort_sdk_js-darwin-universal",
-  "version": "0.2.35-dev",
+  "version": "0.2.35",
   "os": [
     "darwin"
   ],

--- a/packages/cohort_sdk_js/npm/darwin-universal/package.json
+++ b/packages/cohort_sdk_js/npm/darwin-universal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cohort_sdk_js-darwin-universal",
-  "version": "0.2.35",
+  "version": "0.2.36-dev",
   "os": [
     "darwin"
   ],

--- a/packages/cohort_sdk_js/npm/darwin-universal/package.json
+++ b/packages/cohort_sdk_js/npm/darwin-universal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cohort_sdk_js-darwin-universal",
-  "version": "0.2.36",
+  "version": "0.2.37-dev",
   "os": [
     "darwin"
   ],

--- a/packages/cohort_sdk_js/npm/darwin-x64/package.json
+++ b/packages/cohort_sdk_js/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cohort_sdk_js-darwin-x64",
-  "version": "0.2.35",
+  "version": "0.2.36-dev",
   "os": [
     "darwin"
   ],

--- a/packages/cohort_sdk_js/npm/darwin-x64/package.json
+++ b/packages/cohort_sdk_js/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cohort_sdk_js-darwin-x64",
-  "version": "0.2.36",
+  "version": "0.2.37-dev",
   "os": [
     "darwin"
   ],

--- a/packages/cohort_sdk_js/npm/darwin-x64/package.json
+++ b/packages/cohort_sdk_js/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cohort_sdk_js-darwin-x64",
-  "version": "0.2.36-dev",
+  "version": "0.2.36",
   "os": [
     "darwin"
   ],

--- a/packages/cohort_sdk_js/npm/darwin-x64/package.json
+++ b/packages/cohort_sdk_js/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cohort_sdk_js-darwin-x64",
-  "version": "0.2.35-dev",
+  "version": "0.2.35",
   "os": [
     "darwin"
   ],

--- a/packages/cohort_sdk_js/npm/linux-x64-gnu/package.json
+++ b/packages/cohort_sdk_js/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cohort_sdk_js-linux-x64",
-  "version": "0.2.35-dev",
+  "version": "0.2.35",
   "os": [
     "linux"
   ],

--- a/packages/cohort_sdk_js/npm/linux-x64-gnu/package.json
+++ b/packages/cohort_sdk_js/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cohort_sdk_js-linux-x64",
-  "version": "0.2.36",
+  "version": "0.2.37-dev",
   "os": [
     "linux"
   ],

--- a/packages/cohort_sdk_js/npm/linux-x64-gnu/package.json
+++ b/packages/cohort_sdk_js/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cohort_sdk_js-linux-x64",
-  "version": "0.2.36-dev",
+  "version": "0.2.36",
   "os": [
     "linux"
   ],

--- a/packages/cohort_sdk_js/npm/linux-x64-gnu/package.json
+++ b/packages/cohort_sdk_js/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cohort_sdk_js-linux-x64",
-  "version": "0.2.35",
+  "version": "0.2.36-dev",
   "os": [
     "linux"
   ],

--- a/packages/cohort_sdk_js/npm/win32-x64-msvc/package.json
+++ b/packages/cohort_sdk_js/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cohort_sdk_js-win32-x64-msvc",
-  "version": "0.2.35",
+  "version": "0.2.36-dev",
   "os": [
     "win32"
   ],

--- a/packages/cohort_sdk_js/npm/win32-x64-msvc/package.json
+++ b/packages/cohort_sdk_js/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cohort_sdk_js-win32-x64-msvc",
-  "version": "0.2.35-dev",
+  "version": "0.2.35",
   "os": [
     "win32"
   ],

--- a/packages/cohort_sdk_js/npm/win32-x64-msvc/package.json
+++ b/packages/cohort_sdk_js/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cohort_sdk_js-win32-x64-msvc",
-  "version": "0.2.36-dev",
+  "version": "0.2.36",
   "os": [
     "win32"
   ],

--- a/packages/cohort_sdk_js/npm/win32-x64-msvc/package.json
+++ b/packages/cohort_sdk_js/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cohort_sdk_js-win32-x64-msvc",
-  "version": "0.2.36",
+  "version": "0.2.37-dev",
   "os": [
     "win32"
   ],

--- a/packages/cohort_sdk_js/package-lock.json
+++ b/packages/cohort_sdk_js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cohort_sdk_js",
-  "version": "0.2.36",
+  "version": "0.2.37-dev",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cohort_sdk_js",
-      "version": "0.2.36",
+      "version": "0.2.37-dev",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/cohort_sdk_js/package-lock.json
+++ b/packages/cohort_sdk_js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cohort_sdk_js",
-  "version": "0.2.35",
+  "version": "0.2.36-dev",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cohort_sdk_js",
-      "version": "0.2.35",
+      "version": "0.2.36-dev",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/cohort_sdk_js/package-lock.json
+++ b/packages/cohort_sdk_js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cohort_sdk_js",
-  "version": "0.2.35-dev",
+  "version": "0.2.35",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cohort_sdk_js",
-      "version": "0.2.35-dev",
+      "version": "0.2.35",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/cohort_sdk_js/package-lock.json
+++ b/packages/cohort_sdk_js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cohort_sdk_js",
-  "version": "0.2.36-dev",
+  "version": "0.2.36",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cohort_sdk_js",
-      "version": "0.2.36-dev",
+      "version": "0.2.36",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/cohort_sdk_js/package.json
+++ b/packages/cohort_sdk_js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kindredgroup/cohort_sdk_js",
-  "version": "0.2.36-dev",
+  "version": "0.2.36",
   "author": "Kindredgroup",
   "license": "MIT",
   "main": "index.js",

--- a/packages/cohort_sdk_js/package.json
+++ b/packages/cohort_sdk_js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kindredgroup/cohort_sdk_js",
-  "version": "0.2.35-dev",
+  "version": "0.2.35",
   "author": "Kindredgroup",
   "license": "MIT",
   "main": "index.js",

--- a/packages/cohort_sdk_js/package.json
+++ b/packages/cohort_sdk_js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kindredgroup/cohort_sdk_js",
-  "version": "0.2.36",
+  "version": "0.2.37-dev",
   "author": "Kindredgroup",
   "license": "MIT",
   "main": "index.js",

--- a/packages/cohort_sdk_js/package.json
+++ b/packages/cohort_sdk_js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kindredgroup/cohort_sdk_js",
-  "version": "0.2.35",
+  "version": "0.2.36-dev",
   "author": "Kindredgroup",
   "license": "MIT",
   "main": "index.js",

--- a/packages/cohort_sdk_js/src/installer/mod.rs
+++ b/packages/cohort_sdk_js/src/installer/mod.rs
@@ -77,7 +77,6 @@ pub struct InternalReplicator {
 impl InternalReplicator {
     #[napi]
     pub async fn init(kafka_config: JsKafkaConfig, config: JsReplicatorConfig) -> napi::Result<InternalReplicator> {
-        env_logger::builder().format_timestamp_millis().init();
         Ok(InternalReplicator { kafka_config, config })
     }
 

--- a/packages/examples_support/Cargo.toml
+++ b/packages/examples_support/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "examples_support"
-version = "0.2.35-dev"
+version = "0.2.35"
 edition = "2021"
 
 [dependencies]
 
-talos_metrics = { path = "../talos_metrics", version = "0.2.35-dev" }
+talos_metrics = { path = "../talos_metrics", version = "0.2.35" }
 
 # Postgres
 refinery = { version = "0.8.7", features = ["tokio-postgres"] }

--- a/packages/examples_support/Cargo.toml
+++ b/packages/examples_support/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "examples_support"
-version = "0.2.36"
+version = "0.2.37-dev"
 edition = "2021"
 
 [dependencies]
 
-talos_metrics = { path = "../talos_metrics", version = "0.2.36" }
+talos_metrics = { path = "../talos_metrics", version = "0.2.37-dev" }
 
 # Postgres
 refinery = { version = "0.8.7", features = ["tokio-postgres"] }

--- a/packages/examples_support/Cargo.toml
+++ b/packages/examples_support/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "examples_support"
-version = "0.2.36-dev"
+version = "0.2.36"
 edition = "2021"
 
 [dependencies]
 
-talos_metrics = { path = "../talos_metrics", version = "0.2.36-dev" }
+talos_metrics = { path = "../talos_metrics", version = "0.2.36" }
 
 # Postgres
 refinery = { version = "0.8.7", features = ["tokio-postgres"] }

--- a/packages/examples_support/Cargo.toml
+++ b/packages/examples_support/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "examples_support"
-version = "0.2.35"
+version = "0.2.36-dev"
 edition = "2021"
 
 [dependencies]
 
-talos_metrics = { path = "../talos_metrics", version = "0.2.35" }
+talos_metrics = { path = "../talos_metrics", version = "0.2.36-dev" }
 
 # Postgres
 refinery = { version = "0.8.7", features = ["tokio-postgres"] }

--- a/packages/talos_agent/Cargo.toml
+++ b/packages/talos_agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "talos_agent"
-version = "0.2.36-dev"
+version = "0.2.36"
 edition = "2021"
 
 [dependencies]
@@ -24,7 +24,7 @@ time =          { version = "0.3.17" }
 tokio =         { workspace = true, features = ["full"] }
 uuid =          { version = "1.4.1", features = ["v4"] }
 
-talos_rdkafka_utils = { path = "../talos_rdkafka_utils", version = "0.2.36-dev" }
+talos_rdkafka_utils = { path = "../talos_rdkafka_utils", version = "0.2.36" }
 
 [dev-dependencies]
 mockall =       { version = "0.11.3" }

--- a/packages/talos_agent/Cargo.toml
+++ b/packages/talos_agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "talos_agent"
-version = "0.2.35"
+version = "0.2.36-dev"
 edition = "2021"
 
 [dependencies]
@@ -24,7 +24,7 @@ time =          { version = "0.3.17" }
 tokio =         { workspace = true, features = ["full"] }
 uuid =          { version = "1.4.1", features = ["v4"] }
 
-talos_rdkafka_utils = { path = "../talos_rdkafka_utils", version = "0.2.35" }
+talos_rdkafka_utils = { path = "../talos_rdkafka_utils", version = "0.2.36-dev" }
 
 [dev-dependencies]
 mockall =       { version = "0.11.3" }

--- a/packages/talos_agent/Cargo.toml
+++ b/packages/talos_agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "talos_agent"
-version = "0.2.36"
+version = "0.2.37-dev"
 edition = "2021"
 
 [dependencies]
@@ -24,7 +24,7 @@ time =          { version = "0.3.17" }
 tokio =         { workspace = true, features = ["full"] }
 uuid =          { version = "1.4.1", features = ["v4"] }
 
-talos_rdkafka_utils = { path = "../talos_rdkafka_utils", version = "0.2.36" }
+talos_rdkafka_utils = { path = "../talos_rdkafka_utils", version = "0.2.37-dev" }
 
 [dev-dependencies]
 mockall =       { version = "0.11.3" }

--- a/packages/talos_agent/Cargo.toml
+++ b/packages/talos_agent/Cargo.toml
@@ -6,14 +6,20 @@ edition = "2021"
 [dependencies]
 
 async-trait =   { workspace = true }
-env_logger =    { workspace = true }
-log =           { workspace = true }
-multimap =      { version = "0.9.0" }
+multimap =      { version = "0.10.0" }
 rdkafka =       { version = "0.34.0", features = ["sasl"]  }
 serde =         { workspace = true }
 serde_json =    { workspace = true }
-strum =         { version = "0.25", features = ["derive"] }
-thiserror =     { version = "1.0.31" }
+strum =         { version = "0.27.1", features = ["derive"] }
+thiserror =     { version = "2.0.11" }
+
+# Tracing dependencies
+#   We will move telemetry dependencies to the workspace once we adapt all projects. Currenly only SDK uses them.
+opentelemetry =         { version = "0.28.0", default-features = false, features = ["trace"]  }
+tracing =               { version = "0.1.41", features = [ "log" ] }
+tracing-opentelemetry = { version = "0.29.0" }
+# The end of tracing dependencies
+
 time =          { version = "0.3.17" }
 tokio =         { workspace = true, features = ["full"] }
 uuid =          { version = "1.4.1", features = ["v4"] }

--- a/packages/talos_agent/Cargo.toml
+++ b/packages/talos_agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "talos_agent"
-version = "0.2.35-dev"
+version = "0.2.35"
 edition = "2021"
 
 [dependencies]
@@ -24,7 +24,7 @@ time =          { version = "0.3.17" }
 tokio =         { workspace = true, features = ["full"] }
 uuid =          { version = "1.4.1", features = ["v4"] }
 
-talos_rdkafka_utils = { path = "../talos_rdkafka_utils", version = "0.2.35-dev" }
+talos_rdkafka_utils = { path = "../talos_rdkafka_utils", version = "0.2.35" }
 
 [dev-dependencies]
 mockall =       { version = "0.11.3" }

--- a/packages/talos_agent/src/agent/errors.rs
+++ b/packages/talos_agent/src/agent/errors.rs
@@ -108,6 +108,7 @@ mod tests {
                 headers: None,
             },
             Arc::new(Box::new(MockNoopSender::new())),
+            None,
         ));
 
         let agent_error: AgentError = send_error.into();

--- a/packages/talos_agent/src/agent/model.rs
+++ b/packages/talos_agent/src/agent/model.rs
@@ -1,5 +1,9 @@
+use opentelemetry::propagation::{Extractor, Injector};
+use opentelemetry::{global, Context};
+
 use crate::api::{CertificationRequest, CertificationResponse};
 use crate::mpsc::core::Sender;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 // Sent by agent to state manager
@@ -7,13 +11,19 @@ use std::sync::Arc;
 pub struct CertifyRequestChannelMessage {
     pub request: CertificationRequest,
     pub tx_answer: Arc<Box<dyn Sender<Data = CertificationResponse>>>,
+    pub parent_span: Option<(Context, tracing::Id)>,
 }
 
 impl CertifyRequestChannelMessage {
-    pub fn new(request: &CertificationRequest, tx_answer: Arc<Box<dyn Sender<Data = CertificationResponse>>>) -> CertifyRequestChannelMessage {
+    pub fn new(
+        request: &CertificationRequest,
+        tx_answer: Arc<Box<dyn Sender<Data = CertificationResponse>>>,
+        parent_span: Option<(Context, tracing::Id)>,
+    ) -> CertifyRequestChannelMessage {
         CertifyRequestChannelMessage {
             request: request.clone(),
             tx_answer,
+            parent_span,
         }
     }
 }
@@ -22,4 +32,48 @@ impl CertifyRequestChannelMessage {
 #[derive(Debug, Clone)]
 pub struct CancelRequestChannelMessage {
     pub request: CertificationRequest,
+}
+
+#[derive(Default)]
+pub struct PropagatedSpanContextData {
+    data: HashMap<String, String>,
+}
+
+impl PropagatedSpanContextData {
+    pub fn new_with_trace_parent(trace_parent: String) -> Self {
+        Self::new_with_data(HashMap::from([(String::from("traceparent"), trace_parent)]))
+    }
+
+    pub fn new_with_data(data: HashMap<String, String>) -> Self {
+        Self { data }
+    }
+
+    pub fn get_data(self) -> HashMap<String, String> {
+        self.data
+    }
+
+    pub fn new_with_otel_context(otel_context: &opentelemetry::Context) -> Self {
+        global::get_text_map_propagator(|p| {
+            let mut ctx_data = PropagatedSpanContextData::default();
+            p.inject_context(otel_context, &mut ctx_data);
+            ctx_data
+        })
+    }
+}
+
+impl Injector for PropagatedSpanContextData {
+    fn set(&mut self, key: &str, value: String) {
+        self.data.insert(key.to_owned(), value);
+    }
+}
+
+impl Extractor for PropagatedSpanContextData {
+    fn get(&self, key: &str) -> Option<&str> {
+        let key = key.to_owned();
+        self.data.get(&key).map(|v| v.as_ref())
+    }
+
+    fn keys(&self) -> Vec<&str> {
+        self.data.keys().map(|k| k.as_ref()).collect()
+    }
 }

--- a/packages/talos_agent/src/metrics/core.rs
+++ b/packages/talos_agent/src/metrics/core.rs
@@ -136,7 +136,7 @@ impl Metrics {
         let mut elapsed = 0_u64;
         let progress_frequency = if sorted.len() > 10 { (sorted.len() / 10) as u64 } else { 1 };
 
-        log::warn!(
+        tracing::warn!(
             "METRIC agent-spans(header): {},{},{},{},{},{},{},{},{},{},{},'-',{},{}",
             "total count",
             "roundtrip (mcs)",
@@ -160,7 +160,7 @@ impl Metrics {
             //log::error!("debug: {}, {}, {}, {}", tx.id, tx.candidate_publish_4.as_micros(), tx.candidate_kafka_trip_5.as_micros(), tx.decision_duration_6.as_micros());
 
             if total_count % progress_frequency == 0 {
-                log::warn!("METRIC agent-spans(progress): {} of {}", total_count, sorted.len());
+                tracing::warn!("METRIC agent-spans(progress): {} of {}", total_count, sorted.len());
             }
             if earliest_time == 0 {
                 earliest_time = tx.started_at;
@@ -168,7 +168,7 @@ impl Metrics {
 
             elapsed = tx.started_at - earliest_time;
             if elapsed > bucket_limit as u64 {
-                log::warn!(
+                tracing::warn!(
                     "METRIC agent-spans: {},{},{},{},{},{},{},{},{},{},{},'-',{},{}",
                     total_count,
                     sum.total.as_micros(),
@@ -204,7 +204,7 @@ impl Metrics {
             }
         }
 
-        log::warn!(
+        tracing::warn!(
             "METRIC agent-spans: {},{},{},{},{},{},{},{},{},{},{},'-',{},{}",
             total_count,
             sum.total.as_micros(),

--- a/packages/talos_agent/src/metrics/model.rs
+++ b/packages/talos_agent/src/metrics/model.rs
@@ -174,21 +174,21 @@ impl MetricsReport {
     pub fn print(&self, duration_ms: u64, errors_count: u64) {
         let headers = r"'Rroundtrip (mcs)' ['client until agent 1 (mcs)', 'enqueued for in-flight tracing 2 (mcs)', 'publishing task spawn 3 (mcs)', 'kafka publishing 4 (mcs)', 'C. kafka trip 5 (mcs)','decision duration 6 (mcs)', 'D. kafka trip 7 (mcs)', 'agent to client 8 (mcs)']";
 
-        log::warn!("");
-        log::warn!("Publishing: {:>5.2} tps", self.publish_rate);
-        log::warn!("Throuhput:  {:>5.2} tps", self.get_rate(duration_ms));
-        log::warn!("");
-        log::warn!("{}", headers);
-        log::warn!("Max (mcs): {}", self.format_certify_max());
-        log::warn!("Min (mcs): {}", self.format_certify_min());
-        log::warn!("99% (mcs): {}", self.format_p99());
-        log::warn!("95% (mcs): {}", self.format_p95());
-        log::warn!("90% (mcs): {}", self.format_p90());
-        log::warn!("75% (mcs): {}", self.format_p75());
-        log::warn!("50% (mcs): {}", self.format_p50());
-        log::warn!("");
-        log::warn!("Min,Max,p75,p90,p95,Errors");
-        log::warn!(
+        tracing::warn!("");
+        tracing::warn!("Publishing: {:>5.2} tps", self.publish_rate);
+        tracing::warn!("Throuhput:  {:>5.2} tps", self.get_rate(duration_ms));
+        tracing::warn!("");
+        tracing::warn!("{}", headers);
+        tracing::warn!("Max (mcs): {}", self.format_certify_max());
+        tracing::warn!("Min (mcs): {}", self.format_certify_min());
+        tracing::warn!("99% (mcs): {}", self.format_p99());
+        tracing::warn!("95% (mcs): {}", self.format_p95());
+        tracing::warn!("90% (mcs): {}", self.format_p90());
+        tracing::warn!("75% (mcs): {}", self.format_p75());
+        tracing::warn!("50% (mcs): {}", self.format_p50());
+        tracing::warn!("");
+        tracing::warn!("Min,Max,p75,p90,p95,Errors");
+        tracing::warn!(
             "{},{},{},{},{},{}",
             self.certify_min.get_total_mcs(),
             self.certify_max.get_total_mcs(),

--- a/packages/talos_certifier/Cargo.toml
+++ b/packages/talos_certifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "talos_certifier"
-version = "0.2.35"
+version = "0.2.36-dev"
 edition = "2021"
 keywords = ["talos"]
 license = "MIT"
@@ -35,7 +35,7 @@ time = { version = "0.3.30", features = ["formatting"]}
 thiserror = "1.0.31"
 
 # internal crates
-talos_suffix = { path = "../talos_suffix", version = "0.2.35" }
+talos_suffix = { path = "../talos_suffix", version = "0.2.36-dev" }
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/packages/talos_certifier/Cargo.toml
+++ b/packages/talos_certifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "talos_certifier"
-version = "0.2.36-dev"
+version = "0.2.36"
 edition = "2021"
 keywords = ["talos"]
 license = "MIT"
@@ -35,7 +35,7 @@ time = { version = "0.3.30", features = ["formatting"]}
 thiserror = "1.0.31"
 
 # internal crates
-talos_suffix = { path = "../talos_suffix", version = "0.2.36-dev" }
+talos_suffix = { path = "../talos_suffix", version = "0.2.36" }
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/packages/talos_certifier/Cargo.toml
+++ b/packages/talos_certifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "talos_certifier"
-version = "0.2.35-dev"
+version = "0.2.35"
 edition = "2021"
 keywords = ["talos"]
 license = "MIT"
@@ -35,7 +35,7 @@ time = { version = "0.3.30", features = ["formatting"]}
 thiserror = "1.0.31"
 
 # internal crates
-talos_suffix = { path = "../talos_suffix", version = "0.2.35-dev" }
+talos_suffix = { path = "../talos_suffix", version = "0.2.35" }
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/packages/talos_certifier/Cargo.toml
+++ b/packages/talos_certifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "talos_certifier"
-version = "0.2.36"
+version = "0.2.37-dev"
 edition = "2021"
 keywords = ["talos"]
 license = "MIT"
@@ -35,7 +35,7 @@ time = { version = "0.3.30", features = ["formatting"]}
 thiserror = "1.0.31"
 
 # internal crates
-talos_suffix = { path = "../talos_suffix", version = "0.2.36" }
+talos_suffix = { path = "../talos_suffix", version = "0.2.37-dev" }
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/packages/talos_certifier_adapters/Cargo.toml
+++ b/packages/talos_certifier_adapters/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # [package]
 name = "talos_certifier_adapters"
-version = "0.2.36-dev"
+version = "0.2.36"
 edition = "2021"
 keywords = ["talos", "adapters"]
 license = "MIT"
@@ -48,11 +48,11 @@ thiserror = "1.0.31"
 mockall = "0.11.0"
 
 # internal crates
-talos_metrics =       { path = "../talos_metrics", version = "0.2.36-dev" }
-talos_certifier =     { path = "../talos_certifier", version = "0.2.36-dev" }
-talos_suffix =        { path = "../talos_suffix", version = "0.2.36-dev" }
-talos_common_utils =  { path = "../talos_common_utils", version = "0.2.36-dev" }
-talos_rdkafka_utils = { path = "../talos_rdkafka_utils", version = "0.2.36-dev" }
+talos_metrics =       { path = "../talos_metrics", version = "0.2.36" }
+talos_certifier =     { path = "../talos_certifier", version = "0.2.36" }
+talos_suffix =        { path = "../talos_suffix", version = "0.2.36" }
+talos_common_utils =  { path = "../talos_common_utils", version = "0.2.36" }
+talos_rdkafka_utils = { path = "../talos_rdkafka_utils", version = "0.2.36" }
 
 
 [dev-dependencies]

--- a/packages/talos_certifier_adapters/Cargo.toml
+++ b/packages/talos_certifier_adapters/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # [package]
 name = "talos_certifier_adapters"
-version = "0.2.35"
+version = "0.2.36-dev"
 edition = "2021"
 keywords = ["talos", "adapters"]
 license = "MIT"
@@ -48,11 +48,11 @@ thiserror = "1.0.31"
 mockall = "0.11.0"
 
 # internal crates
-talos_metrics =       { path = "../talos_metrics", version = "0.2.35" }
-talos_certifier =     { path = "../talos_certifier", version = "0.2.35" }
-talos_suffix =        { path = "../talos_suffix", version = "0.2.35" }
-talos_common_utils =  { path = "../talos_common_utils", version = "0.2.35" }
-talos_rdkafka_utils = { path = "../talos_rdkafka_utils", version = "0.2.35" }
+talos_metrics =       { path = "../talos_metrics", version = "0.2.36-dev" }
+talos_certifier =     { path = "../talos_certifier", version = "0.2.36-dev" }
+talos_suffix =        { path = "../talos_suffix", version = "0.2.36-dev" }
+talos_common_utils =  { path = "../talos_common_utils", version = "0.2.36-dev" }
+talos_rdkafka_utils = { path = "../talos_rdkafka_utils", version = "0.2.36-dev" }
 
 
 [dev-dependencies]

--- a/packages/talos_certifier_adapters/Cargo.toml
+++ b/packages/talos_certifier_adapters/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # [package]
 name = "talos_certifier_adapters"
-version = "0.2.36"
+version = "0.2.37-dev"
 edition = "2021"
 keywords = ["talos", "adapters"]
 license = "MIT"
@@ -48,11 +48,11 @@ thiserror = "1.0.31"
 mockall = "0.11.0"
 
 # internal crates
-talos_metrics =       { path = "../talos_metrics", version = "0.2.36" }
-talos_certifier =     { path = "../talos_certifier", version = "0.2.36" }
-talos_suffix =        { path = "../talos_suffix", version = "0.2.36" }
-talos_common_utils =  { path = "../talos_common_utils", version = "0.2.36" }
-talos_rdkafka_utils = { path = "../talos_rdkafka_utils", version = "0.2.36" }
+talos_metrics =       { path = "../talos_metrics", version = "0.2.37-dev" }
+talos_certifier =     { path = "../talos_certifier", version = "0.2.37-dev" }
+talos_suffix =        { path = "../talos_suffix", version = "0.2.37-dev" }
+talos_common_utils =  { path = "../talos_common_utils", version = "0.2.37-dev" }
+talos_rdkafka_utils = { path = "../talos_rdkafka_utils", version = "0.2.37-dev" }
 
 
 [dev-dependencies]

--- a/packages/talos_certifier_adapters/Cargo.toml
+++ b/packages/talos_certifier_adapters/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # [package]
 name = "talos_certifier_adapters"
-version = "0.2.35-dev"
+version = "0.2.35"
 edition = "2021"
 keywords = ["talos", "adapters"]
 license = "MIT"
@@ -48,11 +48,11 @@ thiserror = "1.0.31"
 mockall = "0.11.0"
 
 # internal crates
-talos_metrics =       { path = "../talos_metrics", version = "0.2.35-dev" }
-talos_certifier =     { path = "../talos_certifier", version = "0.2.35-dev" }
-talos_suffix =        { path = "../talos_suffix", version = "0.2.35-dev" }
-talos_common_utils =  { path = "../talos_common_utils", version = "0.2.35-dev" }
-talos_rdkafka_utils = { path = "../talos_rdkafka_utils", version = "0.2.35-dev" }
+talos_metrics =       { path = "../talos_metrics", version = "0.2.35" }
+talos_certifier =     { path = "../talos_certifier", version = "0.2.35" }
+talos_suffix =        { path = "../talos_suffix", version = "0.2.35" }
+talos_common_utils =  { path = "../talos_common_utils", version = "0.2.35" }
+talos_rdkafka_utils = { path = "../talos_rdkafka_utils", version = "0.2.35" }
 
 
 [dev-dependencies]

--- a/packages/talos_cohort_replicator/Cargo.toml
+++ b/packages/talos_cohort_replicator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "talos_cohort_replicator"
-version = "0.2.35"
+version = "0.2.36-dev"
 edition = "2021"
 
 [lib]
@@ -26,8 +26,8 @@ time =              { version = "0.3.17" }
 indexmap = { version = "2.0.0", features = ["rayon"]}
 ahash = "0.8.3"
 
-talos_certifier =            { path = "../talos_certifier", version = "0.2.35" }
-talos_suffix =               { path = "../talos_suffix", version = "0.2.35" }
+talos_certifier =            { path = "../talos_certifier", version = "0.2.36-dev" }
+talos_suffix =               { path = "../talos_suffix", version = "0.2.36-dev" }
 
 [dev-dependencies]
 mockall =       { version = "0.11.3" }

--- a/packages/talos_cohort_replicator/Cargo.toml
+++ b/packages/talos_cohort_replicator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "talos_cohort_replicator"
-version = "0.2.36"
+version = "0.2.37-dev"
 edition = "2021"
 
 [lib]
@@ -26,8 +26,8 @@ time =              { version = "0.3.17" }
 indexmap = { version = "2.0.0", features = ["rayon"]}
 ahash = "0.8.3"
 
-talos_certifier =            { path = "../talos_certifier", version = "0.2.36" }
-talos_suffix =               { path = "../talos_suffix", version = "0.2.36" }
+talos_certifier =            { path = "../talos_certifier", version = "0.2.37-dev" }
+talos_suffix =               { path = "../talos_suffix", version = "0.2.37-dev" }
 
 [dev-dependencies]
 mockall =       { version = "0.11.3" }

--- a/packages/talos_cohort_replicator/Cargo.toml
+++ b/packages/talos_cohort_replicator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "talos_cohort_replicator"
-version = "0.2.35-dev"
+version = "0.2.35"
 edition = "2021"
 
 [lib]
@@ -26,8 +26,8 @@ time =              { version = "0.3.17" }
 indexmap = { version = "2.0.0", features = ["rayon"]}
 ahash = "0.8.3"
 
-talos_certifier =            { path = "../talos_certifier", version = "0.2.35-dev" }
-talos_suffix =               { path = "../talos_suffix", version = "0.2.35-dev" }
+talos_certifier =            { path = "../talos_certifier", version = "0.2.35" }
+talos_suffix =               { path = "../talos_suffix", version = "0.2.35" }
 
 [dev-dependencies]
 mockall =       { version = "0.11.3" }

--- a/packages/talos_cohort_replicator/Cargo.toml
+++ b/packages/talos_cohort_replicator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "talos_cohort_replicator"
-version = "0.2.36-dev"
+version = "0.2.36"
 edition = "2021"
 
 [lib]
@@ -26,8 +26,8 @@ time =              { version = "0.3.17" }
 indexmap = { version = "2.0.0", features = ["rayon"]}
 ahash = "0.8.3"
 
-talos_certifier =            { path = "../talos_certifier", version = "0.2.36-dev" }
-talos_suffix =               { path = "../talos_suffix", version = "0.2.36-dev" }
+talos_certifier =            { path = "../talos_certifier", version = "0.2.36" }
+talos_suffix =               { path = "../talos_suffix", version = "0.2.36" }
 
 [dev-dependencies]
 mockall =       { version = "0.11.3" }

--- a/packages/talos_common_utils/Cargo.toml
+++ b/packages/talos_common_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "talos_common_utils"
-version = "0.2.35-dev"
+version = "0.2.35"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/kindredgroup/talos"

--- a/packages/talos_common_utils/Cargo.toml
+++ b/packages/talos_common_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "talos_common_utils"
-version = "0.2.35"
+version = "0.2.36-dev"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/kindredgroup/talos"

--- a/packages/talos_common_utils/Cargo.toml
+++ b/packages/talos_common_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "talos_common_utils"
-version = "0.2.36"
+version = "0.2.37-dev"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/kindredgroup/talos"

--- a/packages/talos_common_utils/Cargo.toml
+++ b/packages/talos_common_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "talos_common_utils"
-version = "0.2.36-dev"
+version = "0.2.36"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/kindredgroup/talos"

--- a/packages/talos_messenger_actions/Cargo.toml
+++ b/packages/talos_messenger_actions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "talos_messenger_actions"
-version = "0.2.35-dev"
+version = "0.2.35"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/kindredgroup/talos"
@@ -45,12 +45,12 @@ ahash = "0.8.3"
 zerofrom = { version = "=0.1.5" }
 litemap = { version = "=0.7.4" }
 
-talos_certifier = { path = "../talos_certifier", version = "0.2.35-dev" }
-talos_suffix = { path = "../talos_suffix", version = "0.2.35-dev" }
-talos_certifier_adapters = { path = "../talos_certifier_adapters", version = "0.2.35-dev" }
-talos_common_utils = { path = "../talos_common_utils", version = "0.2.35-dev" }
-talos_rdkafka_utils = { path = "../talos_rdkafka_utils", version = "0.2.35-dev" }
-talos_messenger_core = { path = "../talos_messenger_core", version = "0.2.35-dev" }
+talos_certifier = { path = "../talos_certifier", version = "0.2.35" }
+talos_suffix = { path = "../talos_suffix", version = "0.2.35" }
+talos_certifier_adapters = { path = "../talos_certifier_adapters", version = "0.2.35" }
+talos_common_utils = { path = "../talos_common_utils", version = "0.2.35" }
+talos_rdkafka_utils = { path = "../talos_rdkafka_utils", version = "0.2.35" }
+talos_messenger_core = { path = "../talos_messenger_core", version = "0.2.35" }
 
 
 [dev-dependencies]

--- a/packages/talos_messenger_actions/Cargo.toml
+++ b/packages/talos_messenger_actions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "talos_messenger_actions"
-version = "0.2.36"
+version = "0.2.37-dev"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/kindredgroup/talos"
@@ -45,12 +45,12 @@ ahash = "0.8.3"
 zerofrom = { version = "=0.1.5" }
 litemap = { version = "=0.7.4" }
 
-talos_certifier = { path = "../talos_certifier", version = "0.2.36" }
-talos_suffix = { path = "../talos_suffix", version = "0.2.36" }
-talos_certifier_adapters = { path = "../talos_certifier_adapters", version = "0.2.36" }
-talos_common_utils = { path = "../talos_common_utils", version = "0.2.36" }
-talos_rdkafka_utils = { path = "../talos_rdkafka_utils", version = "0.2.36" }
-talos_messenger_core = { path = "../talos_messenger_core", version = "0.2.36" }
+talos_certifier = { path = "../talos_certifier", version = "0.2.37-dev" }
+talos_suffix = { path = "../talos_suffix", version = "0.2.37-dev" }
+talos_certifier_adapters = { path = "../talos_certifier_adapters", version = "0.2.37-dev" }
+talos_common_utils = { path = "../talos_common_utils", version = "0.2.37-dev" }
+talos_rdkafka_utils = { path = "../talos_rdkafka_utils", version = "0.2.37-dev" }
+talos_messenger_core = { path = "../talos_messenger_core", version = "0.2.37-dev" }
 
 
 [dev-dependencies]

--- a/packages/talos_messenger_actions/Cargo.toml
+++ b/packages/talos_messenger_actions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "talos_messenger_actions"
-version = "0.2.35"
+version = "0.2.36-dev"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/kindredgroup/talos"
@@ -45,12 +45,12 @@ ahash = "0.8.3"
 zerofrom = { version = "=0.1.5" }
 litemap = { version = "=0.7.4" }
 
-talos_certifier = { path = "../talos_certifier", version = "0.2.35" }
-talos_suffix = { path = "../talos_suffix", version = "0.2.35" }
-talos_certifier_adapters = { path = "../talos_certifier_adapters", version = "0.2.35" }
-talos_common_utils = { path = "../talos_common_utils", version = "0.2.35" }
-talos_rdkafka_utils = { path = "../talos_rdkafka_utils", version = "0.2.35" }
-talos_messenger_core = { path = "../talos_messenger_core", version = "0.2.35" }
+talos_certifier = { path = "../talos_certifier", version = "0.2.36-dev" }
+talos_suffix = { path = "../talos_suffix", version = "0.2.36-dev" }
+talos_certifier_adapters = { path = "../talos_certifier_adapters", version = "0.2.36-dev" }
+talos_common_utils = { path = "../talos_common_utils", version = "0.2.36-dev" }
+talos_rdkafka_utils = { path = "../talos_rdkafka_utils", version = "0.2.36-dev" }
+talos_messenger_core = { path = "../talos_messenger_core", version = "0.2.36-dev" }
 
 
 [dev-dependencies]

--- a/packages/talos_messenger_actions/Cargo.toml
+++ b/packages/talos_messenger_actions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "talos_messenger_actions"
-version = "0.2.36-dev"
+version = "0.2.36"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/kindredgroup/talos"
@@ -45,12 +45,12 @@ ahash = "0.8.3"
 zerofrom = { version = "=0.1.5" }
 litemap = { version = "=0.7.4" }
 
-talos_certifier = { path = "../talos_certifier", version = "0.2.36-dev" }
-talos_suffix = { path = "../talos_suffix", version = "0.2.36-dev" }
-talos_certifier_adapters = { path = "../talos_certifier_adapters", version = "0.2.36-dev" }
-talos_common_utils = { path = "../talos_common_utils", version = "0.2.36-dev" }
-talos_rdkafka_utils = { path = "../talos_rdkafka_utils", version = "0.2.36-dev" }
-talos_messenger_core = { path = "../talos_messenger_core", version = "0.2.36-dev" }
+talos_certifier = { path = "../talos_certifier", version = "0.2.36" }
+talos_suffix = { path = "../talos_suffix", version = "0.2.36" }
+talos_certifier_adapters = { path = "../talos_certifier_adapters", version = "0.2.36" }
+talos_common_utils = { path = "../talos_common_utils", version = "0.2.36" }
+talos_rdkafka_utils = { path = "../talos_rdkafka_utils", version = "0.2.36" }
+talos_messenger_core = { path = "../talos_messenger_core", version = "0.2.36" }
 
 
 [dev-dependencies]

--- a/packages/talos_messenger_core/Cargo.toml
+++ b/packages/talos_messenger_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "talos_messenger_core"
-version = "0.2.35"
+version = "0.2.36-dev"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/kindredgroup/talos"
@@ -41,9 +41,9 @@ time = { version = "0.3.30" }
 indexmap = { version = "2.0.0", features = ["rayon"] }
 ahash = "0.8.3"
 
-talos_certifier = { path = "../talos_certifier", version = "0.2.35" }
-talos_suffix = { path = "../talos_suffix", version = "0.2.35" }
-talos_common_utils = { path = "../../packages/talos_common_utils", version = "0.2.35" }
+talos_certifier = { path = "../talos_certifier", version = "0.2.36-dev" }
+talos_suffix = { path = "../talos_suffix", version = "0.2.36-dev" }
+talos_common_utils = { path = "../../packages/talos_common_utils", version = "0.2.36-dev" }
 
 [dev-dependencies]
 mockall = { version = "0.11.3" }

--- a/packages/talos_messenger_core/Cargo.toml
+++ b/packages/talos_messenger_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "talos_messenger_core"
-version = "0.2.36-dev"
+version = "0.2.36"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/kindredgroup/talos"
@@ -41,9 +41,9 @@ time = { version = "0.3.30" }
 indexmap = { version = "2.0.0", features = ["rayon"] }
 ahash = "0.8.3"
 
-talos_certifier = { path = "../talos_certifier", version = "0.2.36-dev" }
-talos_suffix = { path = "../talos_suffix", version = "0.2.36-dev" }
-talos_common_utils = { path = "../../packages/talos_common_utils", version = "0.2.36-dev" }
+talos_certifier = { path = "../talos_certifier", version = "0.2.36" }
+talos_suffix = { path = "../talos_suffix", version = "0.2.36" }
+talos_common_utils = { path = "../../packages/talos_common_utils", version = "0.2.36" }
 
 [dev-dependencies]
 mockall = { version = "0.11.3" }

--- a/packages/talos_messenger_core/Cargo.toml
+++ b/packages/talos_messenger_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "talos_messenger_core"
-version = "0.2.35-dev"
+version = "0.2.35"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/kindredgroup/talos"
@@ -41,9 +41,9 @@ time = { version = "0.3.30" }
 indexmap = { version = "2.0.0", features = ["rayon"] }
 ahash = "0.8.3"
 
-talos_certifier = { path = "../talos_certifier", version = "0.2.35-dev" }
-talos_suffix = { path = "../talos_suffix", version = "0.2.35-dev" }
-talos_common_utils = { path = "../../packages/talos_common_utils", version = "0.2.35-dev" }
+talos_certifier = { path = "../talos_certifier", version = "0.2.35" }
+talos_suffix = { path = "../talos_suffix", version = "0.2.35" }
+talos_common_utils = { path = "../../packages/talos_common_utils", version = "0.2.35" }
 
 [dev-dependencies]
 mockall = { version = "0.11.3" }

--- a/packages/talos_messenger_core/Cargo.toml
+++ b/packages/talos_messenger_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "talos_messenger_core"
-version = "0.2.36"
+version = "0.2.37-dev"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/kindredgroup/talos"
@@ -41,9 +41,9 @@ time = { version = "0.3.30" }
 indexmap = { version = "2.0.0", features = ["rayon"] }
 ahash = "0.8.3"
 
-talos_certifier = { path = "../talos_certifier", version = "0.2.36" }
-talos_suffix = { path = "../talos_suffix", version = "0.2.36" }
-talos_common_utils = { path = "../../packages/talos_common_utils", version = "0.2.36" }
+talos_certifier = { path = "../talos_certifier", version = "0.2.37-dev" }
+talos_suffix = { path = "../talos_suffix", version = "0.2.37-dev" }
+talos_common_utils = { path = "../../packages/talos_common_utils", version = "0.2.37-dev" }
 
 [dev-dependencies]
 mockall = { version = "0.11.3" }

--- a/packages/talos_metrics/Cargo.toml
+++ b/packages/talos_metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "talos_metrics"
-version = "0.2.36-dev"
+version = "0.2.36"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/kindredgroup/talos"

--- a/packages/talos_metrics/Cargo.toml
+++ b/packages/talos_metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "talos_metrics"
-version = "0.2.36"
+version = "0.2.37-dev"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/kindredgroup/talos"

--- a/packages/talos_metrics/Cargo.toml
+++ b/packages/talos_metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "talos_metrics"
-version = "0.2.35"
+version = "0.2.36-dev"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/kindredgroup/talos"

--- a/packages/talos_metrics/Cargo.toml
+++ b/packages/talos_metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "talos_metrics"
-version = "0.2.35-dev"
+version = "0.2.35"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/kindredgroup/talos"

--- a/packages/talos_rdkafka_utils/Cargo.toml
+++ b/packages/talos_rdkafka_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "talos_rdkafka_utils"
-version = "0.2.35"
+version = "0.2.36-dev"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/kindredgroup/talos"
@@ -15,7 +15,7 @@ doctest = false
 [dependencies]
 async-trait = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt"] }
-talos_common_utils = { path = "../talos_common_utils", version = "0.2.35" }
+talos_common_utils = { path = "../talos_common_utils", version = "0.2.36-dev" }
 # Logging
 log = { workspace = true }
 env_logger = { workspace = true }

--- a/packages/talos_rdkafka_utils/Cargo.toml
+++ b/packages/talos_rdkafka_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "talos_rdkafka_utils"
-version = "0.2.36-dev"
+version = "0.2.36"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/kindredgroup/talos"
@@ -15,7 +15,7 @@ doctest = false
 [dependencies]
 async-trait = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt"] }
-talos_common_utils = { path = "../talos_common_utils", version = "0.2.36-dev" }
+talos_common_utils = { path = "../talos_common_utils", version = "0.2.36" }
 # Logging
 log = { workspace = true }
 env_logger = { workspace = true }

--- a/packages/talos_rdkafka_utils/Cargo.toml
+++ b/packages/talos_rdkafka_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "talos_rdkafka_utils"
-version = "0.2.36"
+version = "0.2.37-dev"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/kindredgroup/talos"
@@ -15,7 +15,7 @@ doctest = false
 [dependencies]
 async-trait = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt"] }
-talos_common_utils = { path = "../talos_common_utils", version = "0.2.36" }
+talos_common_utils = { path = "../talos_common_utils", version = "0.2.37-dev" }
 # Logging
 log = { workspace = true }
 env_logger = { workspace = true }

--- a/packages/talos_rdkafka_utils/Cargo.toml
+++ b/packages/talos_rdkafka_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "talos_rdkafka_utils"
-version = "0.2.35-dev"
+version = "0.2.35"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/kindredgroup/talos"
@@ -15,7 +15,7 @@ doctest = false
 [dependencies]
 async-trait = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt"] }
-talos_common_utils = { path = "../talos_common_utils", version = "0.2.35-dev" }
+talos_common_utils = { path = "../talos_common_utils", version = "0.2.35" }
 # Logging
 log = { workspace = true }
 env_logger = { workspace = true }

--- a/packages/talos_suffix/Cargo.toml
+++ b/packages/talos_suffix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "talos_suffix"
-version = "0.2.35"
+version = "0.2.36-dev"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/kindredgroup/talos"

--- a/packages/talos_suffix/Cargo.toml
+++ b/packages/talos_suffix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "talos_suffix"
-version = "0.2.36"
+version = "0.2.37-dev"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/kindredgroup/talos"

--- a/packages/talos_suffix/Cargo.toml
+++ b/packages/talos_suffix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "talos_suffix"
-version = "0.2.36-dev"
+version = "0.2.36"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/kindredgroup/talos"

--- a/packages/talos_suffix/Cargo.toml
+++ b/packages/talos_suffix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "talos_suffix"
-version = "0.2.35-dev"
+version = "0.2.35"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/kindredgroup/talos"


### PR DESCRIPTION
This work adds tracing and OTEL dependencies to cohort initiator packages. 
Tracing creates spans in critical places, starting from this [main entry-point](https://github.com/kindredgroup/talos/compare/master...feature/cohort-tracing#diff-6f2c4f8c9be7839f3fad785811689294bf8c93f5c4604dcf58b9900c93eb70e9R42). It takes traceparent from the calling JS code, converts it into current span and then creates children as needed.