### PR TITLE
chore: splitting the candidate model between certifier, messenger and replicator

### DIFF
--- a/packages/talos_certifier/src/core.rs
+++ b/packages/talos_certifier/src/core.rs
@@ -1,16 +1,24 @@
 use ahash::HashMap;
 use async_trait::async_trait;
+use serde::de::DeserializeOwned;
 use strum::{Display, EnumString};
 use tokio::sync::broadcast;
 
-use crate::{
-    errors::SystemServiceError,
-    model::{CandidateMessage, DecisionMessage},
-};
+use crate::{errors::SystemServiceError, model::DecisionMessage};
+
+pub trait CandidateMessageBaseTrait: DeserializeOwned {
+    fn get_xid(&self) -> &str;
+    fn get_snapshot(&self) -> u64;
+    fn get_version(&self) -> u64;
+    fn get_agent(&self) -> &str;
+    fn get_cohort(&self) -> &str;
+    fn add_version(&mut self, version: u64);
+    fn add_candidate_received_metric(&mut self, received_at: i128);
+}
 
 #[derive(Debug, Clone)]
-pub struct CandidateChannelMessage {
-    pub message: CandidateMessage,
+pub struct CandidateChannelMessage<T: CandidateMessageBaseTrait> {
+    pub message: T,
     pub headers: HashMap<String, String>,
 }
 
@@ -22,8 +30,8 @@ pub struct DecisionChannelMessage {
 }
 
 #[derive(Debug, Clone)]
-pub enum ChannelMessage {
-    Candidate(Box<CandidateChannelMessage>),
+pub enum ChannelMessage<T: CandidateMessageBaseTrait> {
+    Candidate(Box<CandidateChannelMessage<T>>),
     Decision(Box<DecisionChannelMessage>),
 }
 

--- a/packages/talos_certifier/src/lib.rs
+++ b/packages/talos_certifier/src/lib.rs
@@ -11,3 +11,8 @@ pub mod talos_certifier_service;
 pub use crate::core::{ChannelMessage, SystemMessage};
 pub use certifier::Certifier;
 pub use certifier::CertifierCandidate;
+
+/// Helper functions for building payload and other common test utils
+/// TODO: GK - If this is used across multiple packages and if this grows to be too big,
+/// it would be better to move it to a new package and import in other projects as dev dependency.
+pub mod test_helpers;

--- a/packages/talos_certifier/src/model/candidate_message.rs
+++ b/packages/talos_certifier/src/model/candidate_message.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+
 use std::collections::HashMap;
 
-use crate::certifier::CertifierCandidate;
+use crate::{certifier::CertifierCandidate, core::CandidateMessageBaseTrait};
 
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase", tag = "_typ")]
@@ -22,12 +22,6 @@ pub struct CandidateMessage {
     // OPTIONAL FIELDS
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<HashMap<String, String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub on_commit: Option<Box<Value>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub statemap: Option<Vec<HashMap<String, Value>>>,
-
     /// Cohort started certification
     #[serde(default)]
     pub certification_started_at: i128,
@@ -41,6 +35,34 @@ pub struct CandidateMessage {
     pub received_at: i128,
 }
 
+impl CandidateMessageBaseTrait for CandidateMessage {
+    fn get_xid(&self) -> &str {
+        self.xid.as_str()
+    }
+
+    fn get_snapshot(&self) -> u64 {
+        self.snapshot
+    }
+
+    fn get_version(&self) -> u64 {
+        self.version
+    }
+
+    fn get_agent(&self) -> &str {
+        &self.agent
+    }
+
+    fn get_cohort(&self) -> &str {
+        &self.cohort
+    }
+    fn add_version(&mut self, version: u64) {
+        self.version = version;
+    }
+
+    fn add_candidate_received_metric(&mut self, received_at: i128) {
+        self.received_at = received_at;
+    }
+}
 pub trait CandidateReadWriteSet {
     fn get_readset(&self) -> &Vec<String>;
     fn get_writeset(&self) -> &Vec<String>;

--- a/packages/talos_certifier/src/services/certifier_service.rs
+++ b/packages/talos_certifier/src/services/certifier_service.rs
@@ -27,7 +27,7 @@ pub struct CertifierService {
     pub suffix: Suffix<CandidateMessage>,
     pub certifier: Certifier,
     pub system: System,
-    pub message_channel_rx: mpsc::Receiver<ChannelMessage>,
+    pub message_channel_rx: mpsc::Receiver<ChannelMessage<CandidateMessage>>,
     pub commit_offset: Arc<AtomicI64>,
     pub decision_outbox_tx: mpsc::Sender<DecisionOutboxChannelMessage>,
     pub config: CertifierServiceConfig,
@@ -35,7 +35,7 @@ pub struct CertifierService {
 
 impl CertifierService {
     pub fn new(
-        message_channel_rx: mpsc::Receiver<ChannelMessage>,
+        message_channel_rx: mpsc::Receiver<ChannelMessage<CandidateMessage>>,
         decision_outbox_tx: mpsc::Sender<DecisionOutboxChannelMessage>,
         commit_offset: Arc<AtomicI64>,
         system: System,
@@ -165,7 +165,7 @@ impl CertifierService {
         Ok(())
     }
 
-    pub async fn process_message(&mut self, channel_message: &Option<ChannelMessage>) -> ServiceResult {
+    pub async fn process_message(&mut self, channel_message: &Option<ChannelMessage<CandidateMessage>>) -> ServiceResult {
         if let Err(certification_error) = match channel_message {
             Some(ChannelMessage::Candidate(candidate)) => {
                 let decision_message = self.process_candidate(&candidate.message)?;

--- a/packages/talos_certifier/src/services/message_receiver_service.rs
+++ b/packages/talos_certifier/src/services/message_receiver_service.rs
@@ -10,13 +10,14 @@ use tokio::{sync::mpsc, time::Interval};
 use crate::{
     core::{ServiceResult, System, SystemService},
     errors::{SystemErrorType, SystemServiceError, SystemServiceErrorKind},
+    model::CandidateMessage,
     ports::{errors::MessageReceiverErrorKind, MessageReciever},
     ChannelMessage,
 };
 
 pub struct MessageReceiverService {
-    pub receiver: Box<dyn MessageReciever<Message = ChannelMessage> + Send + Sync>,
-    pub message_channel_tx: mpsc::Sender<ChannelMessage>,
+    pub receiver: Box<dyn MessageReciever<Message = ChannelMessage<CandidateMessage>> + Send + Sync>,
+    pub message_channel_tx: mpsc::Sender<ChannelMessage<CandidateMessage>>,
     pub commit_offset: Arc<AtomicI64>,
     pub system: System,
     pub commit_interval: Interval,
@@ -24,8 +25,8 @@ pub struct MessageReceiverService {
 
 impl MessageReceiverService {
     pub fn new(
-        receiver: Box<dyn MessageReciever<Message = ChannelMessage> + Send + Sync>,
-        message_channel_tx: mpsc::Sender<ChannelMessage>,
+        receiver: Box<dyn MessageReciever<Message = ChannelMessage<CandidateMessage>> + Send + Sync>,
+        message_channel_tx: mpsc::Sender<ChannelMessage<CandidateMessage>>,
         commit_offset: Arc<AtomicI64>,
         system: System,
     ) -> Self {

--- a/packages/talos_certifier/src/services/tests/certifier_service.rs
+++ b/packages/talos_certifier/src/services/tests/certifier_service.rs
@@ -18,7 +18,7 @@ use crate::{
     services::CertifierService,
 };
 
-async fn send_candidate_message(message_channel_tx: mpsc::Sender<ChannelMessage>, candidate_message: CandidateMessage) {
+async fn send_candidate_message(message_channel_tx: mpsc::Sender<ChannelMessage<CandidateMessage>>, candidate_message: CandidateMessage) {
     tokio::spawn(async move {
         message_channel_tx
             .send(ChannelMessage::Candidate(
@@ -35,7 +35,7 @@ async fn send_candidate_message(message_channel_tx: mpsc::Sender<ChannelMessage>
 
 struct CertifierChannels {
     system_channel: (broadcast::Sender<SystemMessage>, broadcast::Receiver<SystemMessage>),
-    message_channel: (mpsc::Sender<ChannelMessage>, mpsc::Receiver<ChannelMessage>),
+    message_channel: (mpsc::Sender<ChannelMessage<CandidateMessage>>, mpsc::Receiver<ChannelMessage<CandidateMessage>>),
     decision_outbox_channel: (mpsc::Sender<DecisionOutboxChannelMessage>, mpsc::Receiver<DecisionOutboxChannelMessage>),
 }
 
@@ -78,8 +78,6 @@ async fn test_certification_rule_2() {
             // readset: vec!["ksp:r1".to_owned(), "ksp:r2".to_owned()],
             writeset: vec!["ksp:w1".to_owned()],
             metadata: None,
-            on_commit: None,
-            statemap: None,
             certification_started_at: 0,
             request_created_at: 0,
             published_at: 0,
@@ -99,8 +97,6 @@ async fn test_certification_rule_2() {
             readset: vec!["ksp:r1".to_owned(), "ksp:r2".to_owned()],
             writeset: vec!["ksp:w1".to_owned()],
             metadata: None,
-            on_commit: None,
-            statemap: None,
             certification_started_at: 0,
             request_created_at: 0,
             published_at: 0,
@@ -157,8 +153,6 @@ async fn test_error_in_processing_candidate_message_certifying() {
             // readset: vec!["ksp:r1".to_owned(), "ksp:r2".to_owned()],
             writeset: vec!["ksp:w1".to_owned()],
             metadata: None,
-            on_commit: None,
-            statemap: None,
             certification_started_at: 0,
             request_created_at: 0,
             published_at: 0,
@@ -212,8 +206,6 @@ async fn test_certification_process_decision() {
             // readset: vec!["ksp:r1".to_owned(), "ksp:r2".to_owned()],
             writeset: vec!["ksp:w1".to_owned()],
             metadata: None,
-            on_commit: None,
-            statemap: None,
             certification_started_at: 0,
             request_created_at: 0,
             published_at: 0,
@@ -281,10 +273,6 @@ async fn test_certification_process_decision_incorrect_version() {
             // readset: vec!["ksp:r1".to_owned(), "ksp:r2".to_owned()],
             writeset: vec!["ksp:w1".to_owned()],
             metadata: None,
-            on_commit: None,
-            // safepoint: None,
-            // decision_outcome: None,
-            statemap: None,
             certification_started_at: 0,
             request_created_at: 0,
             published_at: 0,
@@ -367,8 +355,6 @@ async fn test_certification_check_suffix_prune_is_ready_threshold_30pc() {
             // readset: vec!["ksp:r1".to_owned(), "ksp:r2".to_owned()],
             writeset: vec!["ksp:w1".to_owned()],
             metadata: None,
-            on_commit: None,
-            statemap: None,
             certification_started_at: 0,
             request_created_at: 0,
             published_at: 0,
@@ -390,8 +376,6 @@ async fn test_certification_check_suffix_prune_is_ready_threshold_30pc() {
             // readset: vec!["ksp:r1".to_owned(), "ksp:r2".to_owned()],
             writeset: vec!["ksp:w1".to_owned()],
             metadata: None,
-            on_commit: None,
-            statemap: None,
             certification_started_at: 0,
             request_created_at: 0,
             published_at: 0,
@@ -413,8 +397,6 @@ async fn test_certification_check_suffix_prune_is_ready_threshold_30pc() {
             // readset: vec!["ksp:r1".to_owned(), "ksp:r2".to_owned()],
             writeset: vec!["ksp:w1".to_owned()],
             metadata: None,
-            on_commit: None,
-            statemap: None,
             certification_started_at: 0,
             request_created_at: 0,
             published_at: 0,
@@ -436,8 +418,6 @@ async fn test_certification_check_suffix_prune_is_ready_threshold_30pc() {
             // readset: vec!["ksp:r1".to_owned(), "ksp:r2".to_owned()],
             writeset: vec!["ksp:w1".to_owned()],
             metadata: None,
-            on_commit: None,
-            statemap: None,
             certification_started_at: 0,
             request_created_at: 0,
             published_at: 0,
@@ -459,8 +439,6 @@ async fn test_certification_check_suffix_prune_is_ready_threshold_30pc() {
             // readset: vec!["ksp:r1".to_owned(), "ksp:r2".to_owned()],
             writeset: vec!["ksp:w1".to_owned()],
             metadata: None,
-            on_commit: None,
-            statemap: None,
             certification_started_at: 0,
             request_created_at: 0,
             published_at: 0,
@@ -607,8 +585,6 @@ async fn test_certification_check_suffix_prune_is_not_at_threshold() {
             // readset: vec!["ksp:r1".to_owned(), "ksp:r2".to_owned()],
             writeset: vec!["ksp:w1".to_owned()],
             metadata: None,
-            on_commit: None,
-            statemap: None,
             certification_started_at: 0,
             request_created_at: 0,
             published_at: 0,
@@ -630,8 +606,6 @@ async fn test_certification_check_suffix_prune_is_not_at_threshold() {
             // readset: vec!["ksp:r1".to_owned(), "ksp:r2".to_owned()],
             writeset: vec!["ksp:w1".to_owned()],
             metadata: None,
-            on_commit: None,
-            statemap: None,
             certification_started_at: 0,
             request_created_at: 0,
             published_at: 0,

--- a/packages/talos_certifier/src/services/tests/message_receiver_service.rs
+++ b/packages/talos_certifier/src/services/tests/message_receiver_service.rs
@@ -17,13 +17,13 @@ use crate::{
 };
 
 struct MockReciever {
-    consumer: mpsc::Receiver<ChannelMessage>,
+    consumer: mpsc::Receiver<ChannelMessage<CandidateMessage>>,
     offset: Option<u64>,
 }
 
 #[async_trait]
 impl MessageReciever for MockReciever {
-    type Message = ChannelMessage;
+    type Message = ChannelMessage<CandidateMessage>;
 
     async fn consume_message(&mut self) -> Result<Option<Self::Message>, MessageReceiverError> {
         let msg = self.consumer.recv().await.unwrap();
@@ -100,8 +100,6 @@ async fn test_consume_message() {
         readset: vec![],
         writeset: vec!["ksp:w1".to_owned()],
         metadata: None,
-        on_commit: None,
-        statemap: None,
         certification_started_at: 0,
         request_created_at: 0,
         published_at: 0,
@@ -159,8 +157,6 @@ async fn test_consume_message_error() {
         readset: vec![],
         writeset: vec!["ksp:w1".to_owned()],
         metadata: None,
-        on_commit: None,
-        statemap: None,
         certification_started_at: 0,
         request_created_at: 0,
         published_at: 0,

--- a/packages/talos_certifier/src/test_helpers/mocks/mod.rs
+++ b/packages/talos_certifier/src/test_helpers/mocks/mod.rs
@@ -1,0 +1,1 @@
+pub mod payload;

--- a/packages/talos_certifier/src/test_helpers/mocks/payload.rs
+++ b/packages/talos_certifier/src/test_helpers/mocks/payload.rs
@@ -1,0 +1,44 @@
+use serde_json::{json, Value};
+
+pub fn get_default_headers() -> Value {
+    json!({
+        "headers": {
+            "correlationId": "ef4d684b-cb42-4ff3-9bca-c462699c1672",
+            "version": "1",
+            "type": "SomeMockTypeA",
+        },
+    })
+}
+
+pub fn get_default_payload() -> Value {
+    json!({
+        "firstName": "abc",
+        "lastName": "xyz",
+        "address": "42 Wallaby Way, Sydney, New South Wales, Australia",
+        "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+                        incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip
+                        ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+                        Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+    })
+}
+
+pub fn build_kafka_on_commit_message(topic: &str, key: &str, value: Option<Value>, headers: Option<Value>) -> Value {
+    json!({
+        "cluster": "",
+        "headers": headers.unwrap_or_else(get_default_headers),
+        "key": key,
+        "keyEncoding": "",
+        "partition": null,
+        "topic": topic,
+        "value": value.unwrap_or_else(get_default_payload),
+        "valueEncoding": ""
+    })
+}
+
+pub fn build_on_commit_publish_kafka_payload(kafka_payload: Vec<Value>) -> Value {
+    json!({
+        "publish": {
+            "kafka": kafka_payload
+        }
+    })
+}

--- a/packages/talos_certifier/src/test_helpers/mod.rs
+++ b/packages/talos_certifier/src/test_helpers/mod.rs
@@ -1,0 +1,1 @@
+pub mod mocks;

--- a/packages/talos_certifier_adapters/src/bin/histogram_decision_timeline_from_kafka.rs
+++ b/packages/talos_certifier_adapters/src/bin/histogram_decision_timeline_from_kafka.rs
@@ -1,6 +1,10 @@
 use std::{collections::HashMap, time::Duration};
 
-use talos_certifier::{model::metrics::TxProcessingTimeline, ports::MessageReciever, ChannelMessage};
+use talos_certifier::{
+    model::{metrics::TxProcessingTimeline, CandidateMessage},
+    ports::MessageReciever,
+    ChannelMessage,
+};
 use talos_certifier_adapters::KafkaConsumer;
 use talos_metrics::model::MinMax;
 use talos_rdkafka_utils::kafka_config::KafkaConfig;
@@ -37,7 +41,7 @@ async fn main() -> Result<(), String> {
 
     kafka_consumer.unsubscribe().await;
     kafka_config.group_id = format!("talos-metric-histogram-{}", uuid::Uuid::new_v4());
-    let mut kafka_consumer2 = KafkaConsumer::new(&kafka_config);
+    let mut kafka_consumer2: KafkaConsumer<CandidateMessage> = KafkaConsumer::new(&kafka_config);
 
     kafka_consumer2.subscribe().await.unwrap();
 
@@ -122,7 +126,7 @@ async fn main() -> Result<(), String> {
     Ok(())
 }
 
-async fn aggregate_timelines(consumer: &mut KafkaConsumer) -> Result<(TimelineAggregates, u64), String> {
+async fn aggregate_timelines(consumer: &mut KafkaConsumer<CandidateMessage>) -> Result<(TimelineAggregates, u64), String> {
     let mut total = 0_u64;
     let mut aggregates = TimelineAggregates::default();
     loop {

--- a/packages/talos_certifier_adapters/src/certifier_kafka_pg.rs
+++ b/packages/talos_certifier_adapters/src/certifier_kafka_pg.rs
@@ -1,9 +1,9 @@
-use crate as Adapters;
 use crate::mock_certifier_service::MockCertifierService;
 use crate::PgConfig;
+use crate::{self as Adapters, KafkaConsumer};
 use std::sync::{atomic::AtomicI64, Arc};
 use talos_certifier::core::SystemService;
-use talos_certifier::model::DecisionMessage;
+use talos_certifier::model::{CandidateMessage, DecisionMessage};
 use talos_certifier::ports::DecisionStore;
 
 use talos_certifier::services::CertifierServiceConfig;
@@ -63,7 +63,7 @@ pub async fn certifier_with_kafka_pg(
     /* START - Kafka consumer service  */
     let commit_offset: Arc<AtomicI64> = Arc::new(0.into());
 
-    let kafka_consumer = Adapters::KafkaConsumer::new(&configuration.kafka_config);
+    let kafka_consumer: KafkaConsumer<CandidateMessage> = Adapters::KafkaConsumer::new(&configuration.kafka_config);
     // let kafka_consumer_service = KafkaConsumerService::new(kafka_consumer, tx, system.clone());
     let message_receiver_service = MessageReceiverService::new(Box::new(kafka_consumer), tx, Arc::clone(&commit_offset), system.clone());
 

--- a/packages/talos_certifier_adapters/src/mock_certifier_service.rs
+++ b/packages/talos_certifier_adapters/src/mock_certifier_service.rs
@@ -3,13 +3,13 @@ use async_trait::async_trait;
 use talos_certifier::core::{DecisionOutboxChannelMessage, ServiceResult, SystemService};
 use talos_certifier::errors::{SystemServiceError, SystemServiceErrorKind};
 use talos_certifier::model::metrics::TxProcessingTimeline;
-use talos_certifier::model::{Decision, DecisionMessage};
+use talos_certifier::model::{CandidateMessage, Decision, DecisionMessage};
 use talos_certifier::ports::common::SharedPortTraits;
 use talos_certifier::ChannelMessage;
 use tokio::sync::mpsc;
 
 pub struct MockCertifierService {
-    pub message_channel_rx: mpsc::Receiver<ChannelMessage>,
+    pub message_channel_rx: mpsc::Receiver<ChannelMessage<CandidateMessage>>,
     pub decision_outbox_tx: mpsc::Sender<DecisionOutboxChannelMessage>,
 }
 

--- a/packages/talos_cohort_replicator/src/core.rs
+++ b/packages/talos_cohort_replicator/src/core.rs
@@ -4,6 +4,8 @@ use serde_json::Value;
 use std::marker::PhantomData;
 use talos_certifier::{model::DecisionMessageTrait, ports::MessageReciever, ChannelMessage};
 
+use crate::models::ReplicatorCandidateMessage;
+
 use super::{
     suffix::{ReplicatorSuffixItemTrait, ReplicatorSuffixTrait},
     utils::get_statemap_from_suffix_items,
@@ -66,7 +68,7 @@ pub struct Replicator<T, S, M>
 where
     T: ReplicatorSuffixItemTrait,
     S: ReplicatorSuffixTrait<T> + std::fmt::Debug,
-    M: MessageReciever<Message = ChannelMessage> + Send + Sync,
+    M: MessageReciever<Message = ChannelMessage<ReplicatorCandidateMessage>> + Send + Sync,
 {
     pub receiver: M,
     pub suffix: S,
@@ -79,7 +81,7 @@ impl<T, S, M> Replicator<T, S, M>
 where
     T: ReplicatorSuffixItemTrait,
     S: ReplicatorSuffixTrait<T> + std::fmt::Debug,
-    M: MessageReciever<Message = ChannelMessage> + Send + Sync,
+    M: MessageReciever<Message = ChannelMessage<ReplicatorCandidateMessage>> + Send + Sync,
 {
     pub fn new(receiver: M, suffix: S) -> Self {
         Replicator {

--- a/packages/talos_cohort_replicator/src/models/candidate_message.rs
+++ b/packages/talos_cohort_replicator/src/models/candidate_message.rs
@@ -12,12 +12,6 @@ pub struct ReplicatorCandidateMessage {
     pub agent: String,
     pub cohort: String,
     pub snapshot: u64,
-    // #[serde(skip_deserializing)]
-    // pub readset: Vec<String>,
-    // #[serde(skip_deserializing)]
-    // pub readvers: Vec<u64>,
-    // #[serde(skip_deserializing)]
-    // pub writeset: Vec<String>,
     #[serde(skip_deserializing)]
     pub version: u64,
     // OPTIONAL FIELDS

--- a/packages/talos_cohort_replicator/src/models/candidate_message.rs
+++ b/packages/talos_cohort_replicator/src/models/candidate_message.rs
@@ -1,0 +1,125 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+use talos_certifier::core::CandidateMessageBaseTrait;
+
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
+#[serde(rename_all = "camelCase", tag = "_typ")]
+pub struct ReplicatorCandidateMessage {
+    // UNIQUENESS FIELD
+    pub xid: String,
+    // DATA FIELDS
+    pub agent: String,
+    pub cohort: String,
+    pub snapshot: u64,
+    // #[serde(skip_deserializing)]
+    // pub readset: Vec<String>,
+    // #[serde(skip_deserializing)]
+    // pub readvers: Vec<u64>,
+    // #[serde(skip_deserializing)]
+    // pub writeset: Vec<String>,
+    #[serde(skip_deserializing)]
+    pub version: u64,
+    // OPTIONAL FIELDS
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<HashMap<String, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub statemap: Option<Vec<HashMap<String, Value>>>,
+    /// Cohort started certification
+    #[serde(default)]
+    pub certification_started_at: i128,
+    /// The request for certification is created
+    #[serde(default)]
+    pub request_created_at: i128,
+    /// Candidate published to kafka (agent time)
+    pub published_at: i128,
+    #[serde(skip_deserializing)]
+    /// Candidate received by Certifier
+    pub received_at: i128,
+}
+
+impl CandidateMessageBaseTrait for ReplicatorCandidateMessage {
+    fn get_xid(&self) -> &str {
+        self.xid.as_str()
+    }
+
+    fn get_snapshot(&self) -> u64 {
+        self.snapshot
+    }
+
+    fn get_version(&self) -> u64 {
+        self.version
+    }
+
+    fn get_agent(&self) -> &str {
+        &self.agent
+    }
+
+    fn get_cohort(&self) -> &str {
+        &self.cohort
+    }
+
+    fn add_version(&mut self, version: u64) {
+        self.version = version;
+    }
+
+    fn add_candidate_received_metric(&mut self, received_at: i128) {
+        self.received_at = received_at;
+    }
+}
+
+// // $coverage:ignore-start
+#[cfg(test)]
+mod tests {
+    use log::error;
+    use serde_json::json;
+    use talos_certifier::test_helpers::mocks::payload::{build_kafka_on_commit_message, build_on_commit_publish_kafka_payload};
+
+    use crate::models::ReplicatorCandidateMessage;
+
+    #[test]
+    fn deserialise_using_defaults() {
+        let mut kafka_vec = vec![];
+        for _ in 0..1 {
+            kafka_vec.push(build_kafka_on_commit_message("some-topic", "1234", None, None));
+        }
+
+        let on_commit = build_on_commit_publish_kafka_payload(kafka_vec);
+
+        let json = json!({
+            "xid": "1a5793f8-4ca3-420f-8e81-219e7b039e2a",
+            "agent": "test-agent",
+            "cohort": "test-cohort",
+            "readset": [
+                "c5893d97-30f6-446d-a349-1741f7eff599"
+            ],
+            "readvers": [],
+            "snapshot": 2,
+            "writeset": [
+                "c5893d97-30f6-446d-a349-1741f7eff599"
+            ],
+            "statemap": [
+                {
+                    "SomeStateMap": {
+                        "initialVersion": 0,
+                        "newVersion": 20
+                    }
+                }
+            ],
+            "onCommit": on_commit,
+            "certificationStartedAt": 0,
+            "requestCreatedAt": 0,
+            "publishedAt": 0,
+            "receivedAt": 0,
+        });
+
+        let deserialised: ReplicatorCandidateMessage = serde_json::from_value(json).unwrap();
+        env_logger::init();
+        error!("deserialised candidate message: {deserialised:#?}");
+        assert!(deserialised.statemap.is_some());
+        // let first_statemap = deserialised.statemap.unwrap()[0].contains_key("SomeStateMap");
+        assert!(deserialised.statemap.unwrap()[0].contains_key("SomeStateMap"));
+
+        // assert!(deserialised.statemap[0]);
+    }
+}

--- a/packages/talos_cohort_replicator/src/models/mod.rs
+++ b/packages/talos_cohort_replicator/src/models/mod.rs
@@ -1,5 +1,7 @@
+mod candidate_message;
 mod replicator_candidate;
 mod statemap_installer_queue;
 
+pub use candidate_message::ReplicatorCandidateMessage;
 pub use replicator_candidate::ReplicatorCandidate;
 pub use statemap_installer_queue::StatemapInstallerQueue;

--- a/packages/talos_cohort_replicator/src/models/replicator_candidate.rs
+++ b/packages/talos_cohort_replicator/src/models/replicator_candidate.rs
@@ -2,13 +2,14 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use talos_certifier::model::CandidateMessage;
 
 use crate::{core::CandidateDecisionOutcome, suffix::ReplicatorSuffixItemTrait};
 
+use super::candidate_message::ReplicatorCandidateMessage;
+
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub struct ReplicatorCandidate {
-    pub candidate: CandidateMessage,
+    pub candidate: ReplicatorCandidateMessage,
 
     #[serde(skip_deserializing)]
     pub safepoint: Option<u64>,
@@ -20,8 +21,8 @@ pub struct ReplicatorCandidate {
     pub is_installed: bool,
 }
 
-impl From<CandidateMessage> for ReplicatorCandidate {
-    fn from(candidate: CandidateMessage) -> Self {
+impl From<ReplicatorCandidateMessage> for ReplicatorCandidate {
+    fn from(candidate: ReplicatorCandidateMessage) -> Self {
         ReplicatorCandidate {
             candidate,
             safepoint: None,

--- a/packages/talos_cohort_replicator/src/services/replicator_service.rs
+++ b/packages/talos_cohort_replicator/src/services/replicator_service.rs
@@ -4,7 +4,7 @@ use std::{fmt::Debug, time::Duration};
 use crate::{
     core::{Replicator, ReplicatorChannel, StatemapItem},
     errors::ReplicatorError,
-    models::ReplicatorCandidate,
+    models::{ReplicatorCandidate, ReplicatorCandidateMessage},
     suffix::ReplicatorSuffixTrait,
 };
 
@@ -27,7 +27,7 @@ pub async fn replicator_service<S, M>(
 ) -> Result<(), ReplicatorError>
 where
     S: ReplicatorSuffixTrait<ReplicatorCandidate> + Debug,
-    M: MessageReciever<Message = ChannelMessage> + Send + Sync,
+    M: MessageReciever<Message = ChannelMessage<ReplicatorCandidateMessage>> + Send + Sync,
 {
     info!("Starting Replicator Service.... ");
     let mut interval = tokio::time::interval(Duration::from_millis(config.commit_frequency_ms));

--- a/packages/talos_cohort_replicator/src/talos_cohort_replicator.rs
+++ b/packages/talos_cohort_replicator/src/talos_cohort_replicator.rs
@@ -8,7 +8,7 @@ use crate::{
     callbacks::{ReplicatorInstaller, ReplicatorSnapshotProvider},
     core::Replicator,
     errors::ReplicatorError,
-    models::ReplicatorCandidate,
+    models::{ReplicatorCandidate, ReplicatorCandidateMessage},
     services::{
         replicator_service::{replicator_service, ReplicatorServiceConfig},
         statemap_installer_service::{installation_service, StatemapInstallerConfig},
@@ -79,7 +79,7 @@ pub async fn talos_cohort_replicator<M, Snap>(
     config: CohortReplicatorConfig,
 ) -> Result<((), (), ()), ReplicatorError>
 where
-    M: MessageReciever<Message = ChannelMessage> + Send + Sync + 'static,
+    M: MessageReciever<Message = ChannelMessage<ReplicatorCandidateMessage>> + Send + Sync + 'static,
     Snap: ReplicatorSnapshotProvider + Send + Sync + 'static,
 {
     // ---------- Channels to communicate between threads. ----------

--- a/packages/talos_messenger_core/src/lib.rs
+++ b/packages/talos_messenger_core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod core;
 pub mod errors;
+pub mod models;
 pub mod services;
 pub mod suffix;
 pub mod talos_messenger_service;

--- a/packages/talos_messenger_core/src/models/candidate_message.rs
+++ b/packages/talos_messenger_core/src/models/candidate_message.rs
@@ -12,12 +12,6 @@ pub struct MessengerCandidateMessage {
     pub agent: String,
     pub cohort: String,
     pub snapshot: u64,
-    // #[serde(skip_deserializing)]
-    // pub readset: Vec<String>,
-    // #[serde(skip_deserializing)]
-    // pub readvers: Vec<u64>,
-    // #[serde(skip_deserializing)]
-    // pub writeset: Vec<String>,
     #[serde(skip_deserializing)]
     pub version: u64,
     // OPTIONAL FIELDS
@@ -25,9 +19,6 @@ pub struct MessengerCandidateMessage {
     pub metadata: Option<HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub on_commit: Option<Box<Value>>,
-
-    // #[serde(skip_deserializing)]
-    // pub statemap: Option<Vec<HashMap<String, Value>>>,
     /// Cohort started certification
     #[serde(default)]
     pub certification_started_at: i128,

--- a/packages/talos_messenger_core/src/models/candidate_message.rs
+++ b/packages/talos_messenger_core/src/models/candidate_message.rs
@@ -1,0 +1,123 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+use talos_certifier::core::CandidateMessageBaseTrait;
+
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
+#[serde(rename_all = "camelCase", tag = "_typ")]
+pub struct MessengerCandidateMessage {
+    // UNIQUENESS FIELD
+    pub xid: String,
+    // DATA FIELDS
+    pub agent: String,
+    pub cohort: String,
+    pub snapshot: u64,
+    // #[serde(skip_deserializing)]
+    // pub readset: Vec<String>,
+    // #[serde(skip_deserializing)]
+    // pub readvers: Vec<u64>,
+    // #[serde(skip_deserializing)]
+    // pub writeset: Vec<String>,
+    #[serde(skip_deserializing)]
+    pub version: u64,
+    // OPTIONAL FIELDS
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<HashMap<String, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub on_commit: Option<Box<Value>>,
+
+    // #[serde(skip_deserializing)]
+    // pub statemap: Option<Vec<HashMap<String, Value>>>,
+    /// Cohort started certification
+    #[serde(default)]
+    pub certification_started_at: i128,
+    /// The request for certification is created
+    #[serde(default)]
+    pub request_created_at: i128,
+    /// Candidate published to kafka (agent time)
+    pub published_at: i128,
+    #[serde(skip_deserializing)]
+    /// Candidate received by Certifier
+    pub received_at: i128,
+}
+
+impl CandidateMessageBaseTrait for MessengerCandidateMessage {
+    fn get_xid(&self) -> &str {
+        self.xid.as_str()
+    }
+
+    fn get_snapshot(&self) -> u64 {
+        self.snapshot
+    }
+
+    fn get_version(&self) -> u64 {
+        self.version
+    }
+
+    fn get_agent(&self) -> &str {
+        &self.agent
+    }
+
+    fn get_cohort(&self) -> &str {
+        &self.cohort
+    }
+
+    fn add_version(&mut self, version: u64) {
+        self.version = version;
+    }
+
+    fn add_candidate_received_metric(&mut self, received_at: i128) {
+        self.received_at = received_at;
+    }
+}
+
+// // $coverage:ignore-start
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+    use talos_certifier::test_helpers::mocks::payload::{build_kafka_on_commit_message, build_on_commit_publish_kafka_payload};
+
+    use crate::models::MessengerCandidateMessage;
+
+    #[test]
+    fn deserialise_using_defaults() {
+        let mut kafka_vec = vec![];
+        for _ in 0..1 {
+            kafka_vec.push(build_kafka_on_commit_message("some-topic", "1234", None, None));
+        }
+
+        let on_commit = build_on_commit_publish_kafka_payload(kafka_vec);
+
+        let json = json!({
+            "xid": "1a5793f8-4ca3-420f-8e81-219e7b039e2a",
+            "agent": "test-agent",
+            "cohort": "test-cohort",
+            "readset": [
+                "c5893d97-30f6-446d-a349-1741f7eff599"
+            ],
+            "readvers": [],
+            "snapshot": 2,
+            "writeset": [
+                "c5893d97-30f6-446d-a349-1741f7eff599"
+            ],
+            "statemap": [
+                {
+                    "SomeStateMap": {
+                        "initialVersion": 0,
+                        "newVersion": 20
+                    }
+                }
+            ],
+            "onCommit": on_commit,
+            "certificationStartedAt": 0,
+            "requestCreatedAt": 0,
+            "publishedAt": 0,
+            "receivedAt": 0,
+        });
+
+        let deserialised: MessengerCandidateMessage = serde_json::from_value(json).unwrap();
+        // env_logger::init();
+        // error!("deserialised candidate message: {deserialised:#?}");
+        assert!(deserialised.on_commit.is_some());
+    }
+}

--- a/packages/talos_messenger_core/src/models/mod.rs
+++ b/packages/talos_messenger_core/src/models/mod.rs
@@ -1,0 +1,3 @@
+mod candidate_message;
+
+pub use candidate_message::MessengerCandidateMessage;

--- a/packages/talos_messenger_core/src/services/inbound_service.rs
+++ b/packages/talos_messenger_core/src/services/inbound_service.rs
@@ -15,6 +15,7 @@ use tokio::{
 use crate::{
     core::{MessengerChannelFeedback, MessengerCommitActions, MessengerSystemService},
     errors::{MessengerServiceError, MessengerServiceResult},
+    models::MessengerCandidateMessage,
     suffix::{
         MessengerCandidate, MessengerStateTransitionTimestamps, MessengerSuffixItemTrait, MessengerSuffixTrait, SuffixItemCompleteStateReason, SuffixItemState,
     },
@@ -45,7 +46,7 @@ impl MessengerInboundServiceConfig {
 
 pub struct MessengerInboundService<M>
 where
-    M: MessageReciever<Message = ChannelMessage> + Send + Sync + 'static,
+    M: MessageReciever<Message = ChannelMessage<MessengerCandidateMessage>> + Send + Sync + 'static,
 {
     pub message_receiver: M,
     pub tx_actions_channel: mpsc::Sender<MessengerCommitActions>,
@@ -62,7 +63,7 @@ where
 
 impl<M> MessengerInboundService<M>
 where
-    M: MessageReciever<Message = ChannelMessage> + Send + Sync + 'static,
+    M: MessageReciever<Message = ChannelMessage<MessengerCandidateMessage>> + Send + Sync + 'static,
 {
     pub fn new(
         message_receiver: M,
@@ -230,7 +231,7 @@ where
 
                     },
                     MessengerChannelFeedback::Success(version, key) => {
-                        error!("Successfully processed version={version} with action_key={key}");
+                        debug!("Successfully processed version={version} with action_key={key}");
                         self.handle_action_success(version, &key);
                     },
                 }
@@ -391,7 +392,7 @@ where
 #[async_trait]
 impl<M> MessengerSystemService for MessengerInboundService<M>
 where
-    M: MessageReciever<Message = ChannelMessage> + Send + Sync + 'static,
+    M: MessageReciever<Message = ChannelMessage<MessengerCandidateMessage>> + Send + Sync + 'static,
 {
     async fn start(&self) -> MessengerServiceResult {
         info!("Start Messenger service");

--- a/packages/talos_messenger_core/src/suffix.rs
+++ b/packages/talos_messenger_core/src/suffix.rs
@@ -4,9 +4,11 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::fmt::Debug;
 use strum::{Display, EnumString};
-use talos_certifier::model::{CandidateMessage, Decision, DecisionMessageTrait};
+use talos_certifier::model::{Decision, DecisionMessageTrait};
 use talos_suffix::{core::SuffixResult, Suffix, SuffixTrait};
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+
+use crate::models::MessengerCandidateMessage;
 
 pub trait MessengerSuffixItemTrait: Debug + Clone {
     fn set_state(&mut self, state: SuffixItemState);
@@ -188,7 +190,7 @@ pub struct ActionsMapWithVersion {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub struct MessengerCandidate {
-    pub candidate: CandidateMessage,
+    pub candidate: MessengerCandidateMessage,
     /// Safepoint received for committed outcomes from certifier.
     safepoint: Option<u64>,
     /// Decision received from certifier.
@@ -203,8 +205,8 @@ pub struct MessengerCandidate {
     headers: HashMap<String, String>,
 }
 
-impl From<CandidateMessage> for MessengerCandidate {
-    fn from(candidate: CandidateMessage) -> Self {
+impl From<MessengerCandidateMessage> for MessengerCandidate {
+    fn from(candidate: MessengerCandidateMessage) -> Self {
         let state = SuffixItemState::AwaitingDecision;
         let mut state_transition_ts: HashMap<MessengerStateTransitionTimestamps, TimeStamp> = HashMap::new();
         let timestamp = OffsetDateTime::now_utc().format(&Rfc3339).ok().unwrap();

--- a/packages/talos_messenger_core/src/tests/payload/candidate.rs
+++ b/packages/talos_messenger_core/src/tests/payload/candidate.rs
@@ -4,10 +4,12 @@ use serde_json::{json, Value};
 use talos_certifier::{
     certifier::Outcome,
     core::{CandidateChannelMessage, DecisionChannelMessage},
-    model::{CandidateMessage, DecisionMessage},
+    model::DecisionMessage,
     ChannelMessage,
 };
 use uuid::Uuid;
+
+use crate::models::MessengerCandidateMessage;
 
 pub struct CandidateTestPayload {
     pub message: Value,
@@ -65,17 +67,17 @@ impl Default for CandidateTestPayload {
 //
 
 pub struct MockChannelMessage {
-    candidate: CandidateMessage,
+    candidate: MessengerCandidateMessage,
 }
 
 impl MockChannelMessage {
-    pub fn new(candidate: &CandidateMessage, version: u64) -> Self {
+    pub fn new(candidate: &MessengerCandidateMessage, version: u64) -> Self {
         Self {
-            candidate: CandidateMessage { version, ..candidate.clone() },
+            candidate: MessengerCandidateMessage { version, ..candidate.clone() },
         }
     }
 
-    pub fn build_candidate_channel_message(&self, headers: &HashMap<String, String>) -> ChannelMessage {
+    pub fn build_candidate_channel_message(&self, headers: &HashMap<String, String>) -> ChannelMessage<MessengerCandidateMessage> {
         let channel_candidate = CandidateChannelMessage {
             message: self.candidate.clone(),
             headers: headers.clone(),
@@ -89,7 +91,7 @@ impl MockChannelMessage {
         outcome: &Outcome,
         suffix_start: u64,
         headers: &HashMap<String, String>,
-    ) -> ChannelMessage {
+    ) -> ChannelMessage<MessengerCandidateMessage> {
         let decision = DecisionMessage::new(&self.candidate, outcome.clone(), suffix_start);
 
         let channel_decision = DecisionChannelMessage {

--- a/packages/talos_messenger_core/src/tests/payload/on_commit.rs
+++ b/packages/talos_messenger_core/src/tests/payload/on_commit.rs
@@ -2,51 +2,9 @@ use std::str::FromStr;
 
 use ahash::HashMap;
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use serde_json::Value;
+use talos_certifier::test_helpers::mocks::payload::{get_default_headers, get_default_payload};
 use uuid::Uuid;
-
-pub fn get_default_kafka_headers() -> Value {
-    json!({
-        "headers": {
-            "correlationId": "ef4d684b-cb42-4ff3-9bca-c462699c1672",
-            "version": "1",
-            "type": "KafkaTopicSubType",
-        },
-    })
-}
-
-pub fn get_default_kafka_payload() -> Value {
-    json!({
-        "firstName": "abc",
-        "lastName": "xyz",
-        "address": "42 Wallaby Way, Sydney, New South Wales, Australia",
-        "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
-                        incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip
-                        ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
-                        Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
-    })
-}
-
-pub fn build_kafka_on_commit_message(topic: &str, key: &str, value: Option<Value>, headers: Option<Value>) -> Value {
-    json!({
-        "cluster": "",
-        "headers": headers.unwrap_or_else(get_default_kafka_headers),
-        "key": key,
-        "keyEncoding": "",
-        "partition": null,
-        "topic": topic,
-        "value": value.unwrap_or_else(get_default_kafka_payload),
-        "valueEncoding": ""
-    })
-}
-
-pub fn build_on_commit_publish_kafka_payload(kafka_payload: Vec<Value>) -> Value {
-    json!({
-        "publish": {
-            "kafka": kafka_payload
-        }
-    })
-}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MockOnCommitKafkaMessage {
@@ -72,8 +30,8 @@ impl Default for MockOnCommitKafkaMessage {
         Self {
             topic: "some-topic".to_string(),
             key: Some(uuid_key),
-            headers: Some(serde_json::from_value(get_default_kafka_headers()).unwrap()),
-            value: get_default_kafka_payload(),
+            headers: Some(serde_json::from_value(get_default_headers()).unwrap()),
+            value: get_default_payload(),
         }
     }
 }


### PR DESCRIPTION
Splitting the `candidate` model for certifier, messenger and replicator.

### Reason for this change:
- All these three processes need only a subset of the whole candidate message.
- `on_commit` and `statemap` when deserialised hold either part or whole of the data in `serde_json::Value` field. This bloats the memory.
- When we have huge deeply nested `on_commit` or `statemap` as part of the payload, there is significant memory overhead.
- 
### Old models

|  Service | deserialises `on_commit`  |  deserialises `statemap` | new model  | 
|---|---|---|---|
| certifier  |  ✅  |  ✅  |  `CandidateMessage` | 
| messenger  | ✅  |  ✅ |  `CandidateMessage` | 
| replicator  | ✅  | ✅  | `CandidateMessage`  | 
### New models

|  Service | deserialises `on_commit`  |  deserialises `statemap` | new model  | 
|---|---|---|---|
| certifier  |  ❌  |  ❌  |  `CandidateMessage` | 
| messenger  | ✅  |  ❌ |  `MessengerCandidateMessage` | 
| replicator  | ❌  | ✅  | `ReplicatorCandidateMessage`  | 