### PR TITLE
feat: base for back pressure in talos ecosystem and usage in messenger

### DIFF
--- a/examples/messenger_using_kafka/examples/messenger_using_kafka.rs
+++ b/examples/messenger_using_kafka/examples/messenger_using_kafka.rs
@@ -1,6 +1,9 @@
 use talos_common_utils::env_var;
 use talos_messenger_actions::messenger_with_kafka::{messenger_with_kafka, Configuration};
-use talos_messenger_core::utlis::{create_whitelist_actions_from_str, ActionsParserConfig};
+use talos_messenger_core::{
+    services::TalosBackPressureConfig,
+    utlis::{create_whitelist_actions_from_str, ActionsParserConfig},
+};
 use talos_rdkafka_utils::kafka_config::KafkaConfig;
 use talos_suffix::core::SuffixConfig;
 
@@ -40,6 +43,7 @@ async fn main() {
         channel_buffers: None,
         commit_size: Some(2_000),
         commit_frequency: None,
+        back_pressure_config: Some(TalosBackPressureConfig::new(Some(40), Some(50))),
     };
 
     messenger_with_kafka(config).await.unwrap();

--- a/examples/messenger_using_kafka/examples/messenger_using_kafka.rs
+++ b/examples/messenger_using_kafka/examples/messenger_using_kafka.rs
@@ -1,9 +1,6 @@
-use talos_common_utils::env_var;
+use talos_common_utils::{back_pressure::TalosBackPressureConfig, env_var};
 use talos_messenger_actions::messenger_with_kafka::{messenger_with_kafka, Configuration};
-use talos_messenger_core::{
-    services::TalosBackPressureConfig,
-    utlis::{create_whitelist_actions_from_str, ActionsParserConfig},
-};
+use talos_messenger_core::utlis::{create_whitelist_actions_from_str, ActionsParserConfig};
 use talos_rdkafka_utils::kafka_config::KafkaConfig;
 use talos_suffix::core::SuffixConfig;
 
@@ -43,7 +40,7 @@ async fn main() {
         channel_buffers: None,
         commit_size: Some(2_000),
         commit_frequency: None,
-        back_pressure_config: Some(TalosBackPressureConfig::new(Some(40), Some(50))),
+        back_pressure_config: Some(TalosBackPressureConfig::new(None, Some(50_000))),
     };
 
     messenger_with_kafka(config).await.unwrap();

--- a/packages/talos_common_utils/src/back_pressure.rs
+++ b/packages/talos_common_utils/src/back_pressure.rs
@@ -1,0 +1,76 @@
+#[derive(Debug, Default, Clone)]
+pub struct TalosBackPressureConfig {
+    /// Current count which is used to check against max and min to determine if back-pressure should be applied.
+    pub current: u32,
+    /// Flag denotes if back pressure is enabled, and therefore the thread cannot receive more messages (candidate/decisions) to process.
+    pub is_enabled: bool,
+    /// Max count before back pressue is enabled.
+    /// if `None`, back pressure logic will not apply.
+    pub max_threshold: Option<u32>,
+    /// `min_threshold` helps to prevent immediate toggle between switch on and off of the backpressure.
+    /// Batch of items to process, when back pressure is enabled before disable logic is checked?
+    /// if None, no minimum check is done, and as soon as the count is below the max_threshold, back pressure is disabled.
+    pub min_threshold: Option<u32>,
+}
+
+impl TalosBackPressureConfig {
+    pub fn new(min_threshold: Option<u32>, max_threshold: Option<u32>) -> Self {
+        assert!(
+            min_threshold.le(&max_threshold),
+            "min_threshold ({min_threshold:?}) must be less or equal to the max_threshold ({max_threshold:?})"
+        );
+        Self {
+            max_threshold,
+            min_threshold,
+            is_enabled: false,
+            current: 0,
+        }
+    }
+
+    pub fn increment_current(&mut self) {
+        self.current += 1;
+    }
+
+    pub fn decrement_current(&mut self) {
+        self.current -= 1;
+    }
+
+    /// Get the remaining available count before hitting the max_threshold, and thereby enabling back pressure.
+    pub fn get_remaining_count(&self) -> Option<u32> {
+        self.max_threshold.map(|max| max.saturating_sub(self.current))
+    }
+
+    pub fn update_back_pressure_flag(&mut self, is_enabled: bool) {
+        self.is_enabled = is_enabled
+    }
+
+    /// Looks at the `max_threshold` and `min_threshold` to determine if back pressure should be enabled. `max_threshold` is used to determine when to enable the back-pressure
+    /// whereas, `min_threshold` is used to look at the lower bound
+    /// - `max_threshold` - Use to determine the upper bound of maximum items allowed.
+    ///                     If this is set to `None`, no back pressure will be applied.
+    ///                     `max_threshold` is
+    /// - `min_threshold` - Use to determine the lower bound of maximum items allowed. If this is set to `None`, no back pressure will be applied.
+    pub fn should_apply_back_pressure(&mut self) -> bool {
+        let current_count = self.current;
+        match self.max_threshold {
+            Some(max_threshold) => {
+                // if not enabled, only check against the max_threshold.
+                if current_count >= max_threshold {
+                    true
+                } else {
+                    // if already enabled, check when is it safe to remove.
+
+                    // If there is Some(`min_threshold`), then return true if current_count > `min_threshold`.
+                    // If there is Some(`min_threshold`), then return false if current_count <= `min_threshold`.
+                    // If None, then return false.
+                    match self.min_threshold {
+                        Some(min_threshold) if self.is_enabled => current_count > min_threshold,
+                        _ => false,
+                    }
+                }
+            }
+            // if None, then we don't apply any back pressure.
+            None => false,
+        }
+    }
+}

--- a/packages/talos_common_utils/src/lib.rs
+++ b/packages/talos_common_utils/src/lib.rs
@@ -1,1 +1,2 @@
+pub mod back_pressure;
 pub mod env;

--- a/packages/talos_messenger_actions/src/kafka/service.rs
+++ b/packages/talos_messenger_actions/src/kafka/service.rs
@@ -37,10 +37,13 @@ where
                     commit_actions,
                     headers,
                 } = actions;
-
                 if let Some(publish_actions_for_type) = commit_actions.get(&self.publisher.get_publish_type().to_string()) {
                     match get_actions_deserialised::<Vec<KafkaAction>>(publish_actions_for_type) {
                         Ok(actions) => {
+                            debug!(
+                                "Sending actions for version = {version} \n| Remaining messages in the channel = {}",
+                                self.rx_actions_channel.max_capacity() - self.rx_actions_channel.capacity()
+                            );
                             let total_len = actions.len() as u32;
 
                             let headers_cloned = headers.clone();

--- a/packages/talos_messenger_actions/src/messenger_with_kafka.rs
+++ b/packages/talos_messenger_actions/src/messenger_with_kafka.rs
@@ -7,7 +7,7 @@ use talos_certifier_adapters::KafkaConsumer;
 use talos_messenger_core::{
     core::{MessengerPublisher, PublishActionType},
     errors::{MessengerServiceError, MessengerServiceErrorKind, MessengerServiceResult},
-    services::{MessengerInboundService, MessengerInboundServiceConfig},
+    services::{MessengerInboundService, MessengerInboundServiceConfig, TalosBackPressureConfig},
     suffix::MessengerCandidate,
     talos_messenger_service::TalosMessengerService,
 };
@@ -110,6 +110,8 @@ pub struct Configuration {
     pub commit_size: Option<u32>,
     /// Commit issuing frequency.
     pub commit_frequency: Option<u32>,
+    /// messenger can receive more messages.
+    pub back_pressure_config: Option<TalosBackPressureConfig>,
 }
 
 pub async fn messenger_with_kafka(config: Configuration) -> MessengerServiceResult {
@@ -135,7 +137,14 @@ pub async fn messenger_with_kafka(config: Configuration) -> MessengerServiceResu
     // START - Inbound service
     let suffix: Suffix<MessengerCandidate> = Suffix::with_config(config.suffix_config.unwrap_or_default());
     let inbound_service_config = MessengerInboundServiceConfig::new(config.allowed_actions, config.commit_size, config.commit_frequency);
-    let inbound_service = MessengerInboundService::new(kafka_consumer, tx_actions_channel, rx_feedback_channel, suffix, inbound_service_config);
+    let inbound_service = MessengerInboundService::new(
+        kafka_consumer,
+        tx_actions_channel,
+        rx_feedback_channel,
+        suffix,
+        inbound_service_config,
+        config.back_pressure_config.unwrap_or_default(),
+    );
     // END - Inbound service
 
     // START - Publish service

--- a/packages/talos_messenger_actions/src/messenger_with_kafka.rs
+++ b/packages/talos_messenger_actions/src/messenger_with_kafka.rs
@@ -4,10 +4,11 @@ use log::debug;
 use rdkafka::producer::ProducerContext;
 use talos_certifier::ports::{errors::MessagePublishError, MessageReciever};
 use talos_certifier_adapters::KafkaConsumer;
+use talos_common_utils::back_pressure::TalosBackPressureConfig;
 use talos_messenger_core::{
     core::{MessengerPublisher, PublishActionType},
     errors::{MessengerServiceError, MessengerServiceErrorKind, MessengerServiceResult},
-    services::{MessengerInboundService, MessengerInboundServiceConfig, TalosBackPressureConfig},
+    services::{MessengerInboundService, MessengerInboundServiceConfig},
     suffix::MessengerCandidate,
     talos_messenger_service::TalosMessengerService,
 };

--- a/packages/talos_messenger_core/src/errors.rs
+++ b/packages/talos_messenger_core/src/errors.rs
@@ -1,6 +1,6 @@
 use thiserror::Error as ThisError;
 
-pub type MessengerServiceResult = Result<(), MessengerServiceError>;
+pub type MessengerServiceResult<T = ()> = Result<T, MessengerServiceError>;
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum MessengerActionErrorKind {

--- a/packages/talos_messenger_core/src/services/mod.rs
+++ b/packages/talos_messenger_core/src/services/mod.rs
@@ -1,3 +1,3 @@
 mod inbound_service;
 
-pub use inbound_service::{MessengerInboundService, MessengerInboundServiceConfig};
+pub use inbound_service::{MessengerInboundService, MessengerInboundServiceConfig, TalosBackPressureConfig};

--- a/packages/talos_messenger_core/src/services/mod.rs
+++ b/packages/talos_messenger_core/src/services/mod.rs
@@ -1,3 +1,3 @@
 mod inbound_service;
 
-pub use inbound_service::{MessengerInboundService, MessengerInboundServiceConfig, TalosBackPressureConfig};
+pub use inbound_service::{MessengerInboundService, MessengerInboundServiceConfig};

--- a/packages/talos_messenger_core/src/tests/messenger_inbound_service.rs
+++ b/packages/talos_messenger_core/src/tests/messenger_inbound_service.rs
@@ -173,8 +173,7 @@ async fn test_suffix_item_state_by_on_commit() {
     let on_commit_value = on_commit.as_value();
     let candidate_with_on_commit: MessengerCandidateMessage = CandidateTestPayload::new().add_on_commit(&on_commit_value).build();
     assert!(candidate_with_on_commit.on_commit.is_some());
-    // env_logger::init();
-    // error!("candidate_with_on_commit is \n {candidate_with_on_commit:#?}");
+
     // END - Prepare basic candidates with various different types of on-commit actions.
 
     let headers = HashMap::new();
@@ -945,8 +944,6 @@ async fn test_back_pressure_build_up() {
     let _dm_channel_msg_40 = cm_40.build_decision_channel_message(vers_40 + 2, &commit_outcome, 0, &headers);
 
     //   END - Prepare test candidates and decisions
-
-    env_logger::init();
 
     // --------------------------------------------------------------------------------------------------------------
     //

--- a/packages/talos_messenger_core/src/tests/messenger_inbound_service.rs
+++ b/packages/talos_messenger_core/src/tests/messenger_inbound_service.rs
@@ -1,10 +1,11 @@
 use ahash::{AHashMap, HashMap, HashMapExt};
 use talos_certifier::test_helpers::mocks::payload::{build_kafka_on_commit_message, build_on_commit_publish_kafka_payload, get_default_payload};
+use talos_common_utils::back_pressure::TalosBackPressureConfig;
 use talos_suffix::core::SuffixConfig;
 
 use crate::{
     models::MessengerCandidateMessage,
-    services::{MessengerInboundServiceConfig, TalosBackPressureConfig},
+    services::MessengerInboundServiceConfig,
     suffix::{self, MessengerSuffixAssertionTrait, MessengerSuffixTrait, SuffixItemState},
     tests::{
         payload::{

--- a/packages/talos_messenger_core/src/tests/test_utils.rs
+++ b/packages/talos_messenger_core/src/tests/test_utils.rs
@@ -12,6 +12,7 @@ use talos_certifier::{
     },
     ChannelMessage,
 };
+use talos_common_utils::back_pressure::TalosBackPressureConfig;
 use talos_suffix::{core::SuffixConfig, Suffix};
 
 use tokio::{
@@ -23,7 +24,7 @@ use crate::{
     core::{ActionService, MessengerChannelFeedback, MessengerCommitActions, MessengerPublisher, PublishActionType},
     errors::{MessengerActionError, MessengerServiceResult},
     models::MessengerCandidateMessage,
-    services::{MessengerInboundService, MessengerInboundServiceConfig, TalosBackPressureConfig},
+    services::{MessengerInboundService, MessengerInboundServiceConfig},
     suffix::MessengerCandidate,
     utlis::get_actions_deserialised,
 };
@@ -263,7 +264,7 @@ pub fn build_mock_outcome(conflict_version: Option<u64>, safepoint: Option<u64>)
 pub struct MessengerServicesTesterConfigs {
     suffix_configs: SuffixConfig,
     inbound_service_configs: MessengerInboundServiceConfig,
-    backpressure_configs: TalosBackPressureConfig,
+    back_pressure_configs: TalosBackPressureConfig,
 }
 
 impl MessengerServicesTesterConfigs {
@@ -271,7 +272,7 @@ impl MessengerServicesTesterConfigs {
         MessengerServicesTesterConfigs {
             suffix_configs,
             inbound_service_configs,
-            backpressure_configs,
+            back_pressure_configs: backpressure_configs,
         }
     }
 }
@@ -326,7 +327,7 @@ impl MessengerServiceTester<MockActionService, MockReciever, ChannelMessage<Mess
             rx_feedback_channel,
             suffix,
             configs.inbound_service_configs,
-            configs.backpressure_configs,
+            configs.back_pressure_configs,
         );
 
         // START - Mock Action Service


### PR DESCRIPTION
- Base struct `TalosBackPressureConfig` which could be added to any service in talos ecosystem with all the essential methods to capture and determine if back pressure is required.
- Usage of `TalosBackPressureConfig` in Talos messenger service.