### PR TITLE
feat: deserialise messenger on_commit actions using RawValues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ env_logger = "0.10"
 
 # Json Serialize / Deserialize
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["raw_value"] }
 
 # Async
 tokio = { version = "1", features = ["full", "test-util"] }

--- a/packages/talos_messenger_actions/src/kafka/service.rs
+++ b/packages/talos_messenger_actions/src/kafka/service.rs
@@ -10,7 +10,7 @@ use talos_messenger_core::{
     core::{ActionService, MessengerChannelFeedback, MessengerCommitActions, MessengerPublisher, MessengerSystemService},
     errors::MessengerServiceResult,
     suffix::MessengerStateTransitionTimestamps,
-    utlis::get_actions_deserialised,
+    utlis::get_action_deserialised,
 };
 
 use super::models::KafkaAction;
@@ -38,36 +38,36 @@ where
                     headers,
                 } = actions;
 
-                if let Some(publish_actions_for_type) = commit_actions.get(&self.publisher.get_publish_type().to_string()) {
-                    match get_actions_deserialised::<Vec<KafkaAction>>(publish_actions_for_type) {
-                        Ok(actions) => {
-                            let total_len = actions.len() as u32;
+                if let Some(publish_actions) = commit_actions.get(&self.publisher.get_publish_type().to_string()) {
+                    let total_len = publish_actions.len() as u32;
+                    let mut publish_vec = vec![];
+                    for publish_action in publish_actions {
+                        match get_action_deserialised::<KafkaAction>(publish_action.clone()) {
+                            Ok(action) => {
+                                let headers_cloned = headers.clone();
 
-                            let headers_cloned = headers.clone();
-
-                            let publish_vec = actions.into_iter().map(|action| {
                                 let publisher = self.publisher.clone();
                                 let mut headers = headers_cloned.clone();
                                 let timestamp = OffsetDateTime::now_utc().format(&Rfc3339).ok().unwrap();
 
                                 headers.insert(MessengerStateTransitionTimestamps::EndOnCommitActions.to_string(), timestamp);
-                                async move {
+                                publish_vec.push(async move {
                                     if let Err(publish_error) = publisher.send(version, action, headers, total_len).await {
                                         error!("Failed to publish message for version={version} with error {publish_error}")
                                     }
-                                }
-                            });
-                            join_all(publish_vec).await;
-                        }
-                        Err(err) => {
-                            error!(
-                                "Failed to deserialise for version={version} key={} for data={:?} with error={:?}",
-                                &self.publisher.get_publish_type(),
-                                err.data,
-                                err.reason
-                            );
+                                });
+                            }
+                            Err(err) => {
+                                error!(
+                                    "Failed to deserialise for version={version} key={} for data={:?} with error={:?}",
+                                    &self.publisher.get_publish_type(),
+                                    err.data,
+                                    err.reason
+                                );
+                            }
                         }
                     }
+                    join_all(publish_vec).await;
                 }
             }
             None => {

--- a/packages/talos_messenger_core/src/core.rs
+++ b/packages/talos_messenger_core/src/core.rs
@@ -1,7 +1,7 @@
 use ahash::HashMap;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::value::RawValue;
 use strum::{Display, EnumIter, EnumString};
 use talos_certifier::ports::errors::MessagePublishError;
 
@@ -50,7 +50,7 @@ pub trait MessengerSystemService {
 #[derive(Debug, Clone)]
 pub struct MessengerCommitActions {
     pub version: u64,
-    pub commit_actions: HashMap<String, Value>,
+    pub commit_actions: HashMap<String, Vec<Box<RawValue>>>,
     pub headers: HashMap<String, String>,
 }
 

--- a/packages/talos_messenger_core/src/models/mod.rs
+++ b/packages/talos_messenger_core/src/models/mod.rs
@@ -1,3 +1,3 @@
 mod candidate_message;
 
-pub use candidate_message::MessengerCandidateMessage;
+pub use candidate_message::{MessengerCandidateMessage, OnCommitActions};

--- a/packages/talos_messenger_core/src/tests/messenger_inbound_service.rs
+++ b/packages/talos_messenger_core/src/tests/messenger_inbound_service.rs
@@ -1,4 +1,5 @@
 use ahash::{AHashMap, HashMap, HashMapExt};
+use serde_json::json;
 use talos_certifier::test_helpers::mocks::payload::{build_kafka_on_commit_message, build_on_commit_publish_kafka_payload, get_default_payload};
 use talos_suffix::core::SuffixConfig;
 
@@ -154,8 +155,7 @@ async fn test_suffix_item_state_by_on_commit() {
     assert!(candidate_with_no_on_commit.on_commit.is_none());
 
     // Candidate with no supported on-commit action
-    let on_commit = MockOnCommitMessage::build_from_str(r#"{"notSuportedAction": {"name": "Kindred"}}"#);
-    let on_commit_value = on_commit.as_value();
+    let on_commit_value = json!({"notSuportedAction": {"subAction": [{"name": "Kindred"}]}});
 
     let candidate_with_irrelevant_on_commit: MessengerCandidateMessage = CandidateTestPayload::new().add_on_commit(&on_commit_value).build();
     assert!(candidate_with_irrelevant_on_commit.on_commit.is_some());
@@ -489,8 +489,7 @@ async fn test_suffix_exhaustive_state_transitions_without_pruning() {
     let candidate_with_no_on_commit: MessengerCandidateMessage = CandidateTestPayload::new().build();
     assert!(candidate_with_no_on_commit.on_commit.is_none());
     // Candidate with no supported on-commit action
-    let on_commit = MockOnCommitMessage::build_from_str(r#"{"notSuportedAction": {"name": "Kindred"}}"#);
-    let on_commit_value = on_commit.as_value();
+    let on_commit_value = json!({"notSuportedAction": {"subAction": [{"name": "Kindred"}]}});
 
     let candidate_with_irrelevant_on_commit: MessengerCandidateMessage = CandidateTestPayload::new().add_on_commit(&on_commit_value).build();
     assert!(candidate_with_irrelevant_on_commit.on_commit.is_some());
@@ -796,8 +795,7 @@ async fn test_suffix_prune_index_update_all_candidates_with_commit_decision_earl
     let candidate_with_no_on_commit: MessengerCandidateMessage = CandidateTestPayload::new().build();
     assert!(candidate_with_no_on_commit.on_commit.is_none());
     // Candidate with no supported on-commit action
-    let on_commit = MockOnCommitMessage::build_from_str(r#"{"notSuportedAction": {"name": "Kindred"}}"#);
-    let on_commit_value = on_commit.as_value();
+    let on_commit_value = json!({"notSuportedAction": {"subAction": [{"name": "Kindred"}]}});
 
     let candidate_with_irrelevant_on_commit: MessengerCandidateMessage = CandidateTestPayload::new().add_on_commit(&on_commit_value).build();
     assert!(candidate_with_irrelevant_on_commit.on_commit.is_some());

--- a/packages/talos_messenger_core/src/tests/utils.rs
+++ b/packages/talos_messenger_core/src/tests/utils.rs
@@ -1,7 +1,10 @@
 use ahash::{HashMap, HashMapExt};
-use serde_json::{json, Value};
+use serde_json::{json, value::RawValue};
 
-use crate::utlis::{create_whitelist_actions_from_str, get_actions_deserialised, get_allowed_commit_actions, ActionsParserConfig};
+use crate::{
+    models::OnCommitActions,
+    utlis::{create_whitelist_actions_from_str, get_action_deserialised, get_allowed_commit_actions, ActionsParserConfig},
+};
 
 // Start - testing create_whitelist_actions_from_str function
 #[test]
@@ -50,26 +53,28 @@ fn test_fn_get_allowed_commit_actions_allowed_actions_negative_scenarios() {
         }
     });
 
+    let on_commit_actions_deserialised: OnCommitActions = serde_json::from_value(on_commit_actions).unwrap();
+
     // When allowed action map is empty.
-    let result = get_allowed_commit_actions(&on_commit_actions, &allowed_actions);
+    let result = get_allowed_commit_actions(&on_commit_actions_deserialised, &allowed_actions);
     assert!(result.is_empty());
 
     // When allowed action is supported type by the messenger, but the sub actions are not provided
     allowed_actions.clear();
     allowed_actions.insert("publish".to_string(), vec![]);
-    let result = get_allowed_commit_actions(&on_commit_actions, &allowed_actions);
+    let result = get_allowed_commit_actions(&on_commit_actions_deserialised, &allowed_actions);
     assert!(result.is_empty());
 
     // When allowed action is supported type by the messenger, but the sub actions are not supported
     allowed_actions.clear();
     allowed_actions.insert("publish".to_string(), vec!["sqs".to_string(), "sns".to_string()]);
-    let result = get_allowed_commit_actions(&on_commit_actions, &allowed_actions);
+    let result = get_allowed_commit_actions(&on_commit_actions_deserialised, &allowed_actions);
     assert!(result.is_empty());
 
     // When allowed action is non supported type by the messenger, with empty sub type
     allowed_actions.clear();
     allowed_actions.insert("random".to_string(), vec![]);
-    let result = get_allowed_commit_actions(&on_commit_actions, &allowed_actions);
+    let result = get_allowed_commit_actions(&on_commit_actions_deserialised, &allowed_actions);
     assert!(result.is_empty());
 
     // When allowed action is non supported type by the messenger, but has valid sub actions
@@ -78,7 +83,7 @@ fn test_fn_get_allowed_commit_actions_allowed_actions_negative_scenarios() {
         "random".to_string(),
         vec!["sqs".to_string(), "sns".to_string(), "kafka".to_string(), "mqtt".to_string()],
     );
-    let result = get_allowed_commit_actions(&on_commit_actions, &allowed_actions);
+    let result = get_allowed_commit_actions(&on_commit_actions_deserialised, &allowed_actions);
     assert!(result.is_empty());
 }
 
@@ -92,39 +97,36 @@ fn test_fn_get_allowed_commit_actions_on_commit_action_negative_scenarios() {
 
     // When on_commit_actions are not present
     let on_commit_actions = serde_json::json!({});
-    let result = get_allowed_commit_actions(&on_commit_actions, &allowed_actions);
+    let on_commit_actions_deserialised: OnCommitActions = serde_json::from_value(on_commit_actions).unwrap();
+
+    let result = get_allowed_commit_actions(&on_commit_actions_deserialised, &allowed_actions);
     assert!(result.is_empty());
 
-    // When on_commit_actions is of type not supported by messenger
-    // 1. When actions is an array
-    let on_commit_actions = serde_json::json!([1, 2, 3, 4]);
-    let result = get_allowed_commit_actions(&on_commit_actions, &allowed_actions);
-    assert!(result.is_empty());
-
-    // 2. When actions is some other object type
+    // When actions is some other object type
     let on_commit_actions = serde_json::json!({
         "test": {
-            "a": "foo",
-            "kafka": "bar"
+            "a": vec!["foo"],
+            "kafka": vec!["bar"]
         }
     });
-    let result = get_allowed_commit_actions(&on_commit_actions, &allowed_actions);
+    let on_commit_actions_deserialised: OnCommitActions = serde_json::from_value(on_commit_actions).unwrap();
+    let result = get_allowed_commit_actions(&on_commit_actions_deserialised, &allowed_actions);
     assert!(result.is_empty());
 
     // When on_commit_actions is valid json supported by messenger, but not the action required by messenger
     let on_commit_actions = serde_json::json!({
-        "random": {
-            "kafka": [
-                {
-                    "_typ": "KafkaMessage",
-                    "topic": "${env}.chimera.coupons", // ${env} is substituted by the Kafka provider
-                    "value": "test"
-                },
-                {
-                    "_typ": "KafkaMessage",
-                    "topic": "${env}.chimera.coupons", // ${env} is substituted by the Kafka provider
-                    "value": "test"
-                }
+    "random": {
+        "kafka": [
+            {
+                "_typ": "KafkaMessage",
+                "topic": "${env}.chimera.coupons", // ${env} is substituted by the Kafka provider
+                "value": "test"
+            },
+            {
+                "_typ": "KafkaMessage",
+                "topic": "${env}.chimera.coupons", // ${env} is substituted by the Kafka provider
+                "value": "test"
+            }
             ],
             "mqtt": [
                 {
@@ -132,20 +134,22 @@ fn test_fn_get_allowed_commit_actions_on_commit_action_negative_scenarios() {
                     "topic": "${env}.chimera.coupons", // ${env} is substituted by the Kafka provider
                     "value": "test"
                 }
-            ]
-        }
-    });
-    let result = get_allowed_commit_actions(&on_commit_actions, &allowed_actions);
+                ]
+            }
+        });
+    let on_commit_actions_deserialised: OnCommitActions = serde_json::from_value(on_commit_actions).unwrap();
+    let result = get_allowed_commit_actions(&on_commit_actions_deserialised, &allowed_actions);
     assert!(result.is_empty());
 
     // When on_commit_actions is valid json supported by messenger, with valid action, but the sub-actions are not supported by messenger
     let on_commit_actions = serde_json::json!({
         "publish": {
-            "foo": "Lorem",
-            "bar": "Ipsum"
+            "foo": vec!["Lorem"],
+            "bar": vec!["Ipsum"]
         }
     });
-    let result = get_allowed_commit_actions(&on_commit_actions, &allowed_actions);
+    let on_commit_actions_deserialised: OnCommitActions = serde_json::from_value(on_commit_actions).unwrap();
+    let result = get_allowed_commit_actions(&on_commit_actions_deserialised, &allowed_actions);
     assert!(result.is_empty());
 }
 
@@ -154,18 +158,18 @@ fn test_fn_get_allowed_commit_actions_positive_scenario() {
     let mut allowed_actions = HashMap::new();
 
     let on_commit_actions = serde_json::json!({
-        "publish": {
-            "kafka": [
-                {
-                    "_typ": "KafkaMessage",
-                    "topic": "${env}.chimera.coupons", // ${env} is substituted by the Kafka provider
-                    "value": "test"
-                },
-                {
-                    "_typ": "KafkaMessage",
-                    "topic": "${env}.chimera.coupons", // ${env} is substituted by the Kafka provider
-                    "value": "test"
-                }
+    "publish": {
+        "kafka": [
+            {
+                "_typ": "KafkaMessage",
+                "topic": "${env}.chimera.coupons", // ${env} is substituted by the Kafka provider
+                "value": "test"
+            },
+            {
+                "_typ": "KafkaMessage",
+                "topic": "${env}.chimera.coupons", // ${env} is substituted by the Kafka provider
+                "value": "test"
+            }
             ],
             "mqtt": [
                 {
@@ -173,15 +177,16 @@ fn test_fn_get_allowed_commit_actions_positive_scenario() {
                     "topic": "${env}.chimera.coupons", // ${env} is substituted by the Kafka provider
                     "value": "test"
                 }
-            ]
-        }
-    });
+                ]
+            }
+        });
+    let on_commit_actions_deserialised: OnCommitActions = serde_json::from_value(on_commit_actions).unwrap();
 
     allowed_actions.insert(
         "publish".to_string(),
         vec!["sqs".to_string(), "sns".to_string(), "kafka".to_string(), "mqtt".to_string()],
     );
-    let result = get_allowed_commit_actions(&on_commit_actions, &allowed_actions);
+    let result = get_allowed_commit_actions(&on_commit_actions_deserialised, &allowed_actions);
     assert_eq!(result.len(), 2);
 }
 
@@ -198,30 +203,40 @@ fn test_fn_get_allowed_commit_actions_positive_scenario() {
 // 2. Key
 #[test]
 fn test_fn_get_actions_deserialised_actions_incorrect_arguments() {
-    let mut actions_map: HashMap<String, Value> = HashMap::new();
+    let mut actions_map: HashMap<String, Box<RawValue>> = HashMap::new();
 
-    // When value is empty string.
-    actions_map.insert("kafka".to_string(), "".into());
-    let result = get_actions_deserialised::<Vec<String>>(actions_map.get("kafka").unwrap());
+    // When value is  string.
+    let json = json!("");
+    let json_raw_value = RawValue::from_string(json.to_string()).unwrap();
+    actions_map.insert("kafka".to_string(), *Box::new(json_raw_value));
+    let result = get_action_deserialised::<i32>(actions_map.get("kafka").unwrap().clone());
     assert!(result.is_err());
 
     // When value is Array of string, but we want to parse it to array of u32.
-    actions_map.insert("kafka".to_string(), vec!["foo", "bar"].into());
-    let result = get_actions_deserialised::<Vec<u32>>(actions_map.get("kafka").unwrap());
+    let json = json!(vec!["foo", "bar"]);
+    let json_raw_value = RawValue::from_string(json.to_string()).unwrap();
+
+    actions_map.insert("kafka".to_string(), json_raw_value);
+    let result = get_action_deserialised::<Vec<u32>>(actions_map.get("kafka").unwrap().clone());
     assert!(result.is_err());
 }
 #[test]
 fn test_fn_get_actions_deserialised_actions_correct_arguments_passed() {
-    let mut actions_map: HashMap<String, Value> = HashMap::new();
+    let mut actions_map: HashMap<String, Box<RawValue>> = HashMap::new();
 
     // When value is empty string.
-    actions_map.insert("kafka".to_string(), "".into());
-    let result = get_actions_deserialised::<String>(actions_map.get("kafka").unwrap());
+    let json = json!("");
+    let json_raw_value = RawValue::from_string(json.to_string()).unwrap();
+    actions_map.insert("kafka".to_string(), json_raw_value);
+    let result = get_action_deserialised::<String>(actions_map.get("kafka").unwrap().clone());
     assert!(result.is_ok());
 
     // When value is Array of string.
-    actions_map.insert("kafka".to_string(), vec!["foo", "bar"].into());
-    let result = get_actions_deserialised::<Vec<String>>(actions_map.get("kafka").unwrap());
+
+    let json = json!(vec!["foo", "bar"]);
+    let json_raw_value = RawValue::from_string(json.to_string()).unwrap();
+    actions_map.insert("kafka".to_string(), json_raw_value);
+    let result = get_action_deserialised::<Vec<String>>(actions_map.get("kafka").unwrap().clone());
     assert!(result.is_ok());
 
     // More complex type
@@ -233,18 +248,14 @@ fn test_fn_get_actions_deserialised_actions_correct_arguments_passed() {
         state: String,
     }
 
-    actions_map.insert(
-        "address".to_string(),
-        json!(
-
-            {
-                "street_number": 47,
-                "street": "Wallaby Way".to_string(),
-                "city": "Sydney".to_string(),
-                "state": "New South Wales".to_string(),
-            }
-        ),
-    );
-    let result = get_actions_deserialised::<Address>(actions_map.get("address").unwrap());
+    let json = json!({
+        "street_number": 47,
+        "street": "Wallaby Way".to_string(),
+        "city": "Sydney".to_string(),
+        "state": "New South Wales".to_string(),
+    });
+    let json_raw_value = RawValue::from_string(json.to_string()).unwrap();
+    actions_map.insert("address".to_string(), json_raw_value);
+    let result = get_action_deserialised::<Address>(actions_map.get("address").unwrap().clone());
     assert!(result.is_ok());
 }


### PR DESCRIPTION
- `serde_json::Value` is very resource intensive. On a high load, lot of CPU is spend on deserialising the payload and the memory gets bloated. This has a direct impact on the overall throughput and latency messenger can achieve.

- Messenger only needs partially deserialisation at various points before the messages are finally send out by the kafka producer thread. 

- Therefore using `serde_json::RawValues` is more efficient on the memory and CPU and thereby has significant boost in performance on high load.
 