### PR TITLE
chore: certifier suffix reset and commit with minimum offset threshold

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3244,6 +3244,7 @@ dependencies = [
  "async-trait",
  "deadpool-postgres",
  "env_logger",
+ "futures-executor",
  "futures-util",
  "log",
  "mockall",

--- a/examples/certifier_kafka_pg/examples/certifier_kafka_pg.rs
+++ b/examples/certifier_kafka_pg/examples/certifier_kafka_pg.rs
@@ -16,7 +16,18 @@ async fn main() -> Result<(), impl std::error::Error> {
 
     info!("Talos certifier starting...");
 
-    let kafka_config = KafkaConfig::from_env(None);
+    let mut kafka_config = KafkaConfig::from_env(None);
+    kafka_config.extend(
+        None,
+        Some(
+            [
+                // ("debug".to_owned(), "all".to_owned()),
+                ("enable.auto.commit".to_string(), "false".to_string()),
+                ("auto.offset.reset".to_string(), "earliest".to_string()),
+            ]
+            .into(),
+        ),
+    );
     // kafka_config.extend(None, None);
 
     let pg_config = PgConfig::from_env();
@@ -34,6 +45,8 @@ async fn main() -> Result<(), impl std::error::Error> {
         kafka_config,
         db_mock: mock_config.db_mock,
         app_name: None,
+        commit_frequency_ms: Some(10_000),
+        min_commit_threshold: Some(50_000),
     };
 
     let talos_certifier = certifier_with_kafka_pg(TalosCertifierChannelBuffers::default(), configuration).await?;

--- a/packages/talos_certifier/src/certifier/certification.rs
+++ b/packages/talos_certifier/src/certifier/certification.rs
@@ -1,4 +1,5 @@
 use ahash::AHashMap;
+use log::debug;
 
 use super::CertifierCandidate;
 
@@ -81,6 +82,10 @@ impl Certifier {
 
         // Rule R2: Conditional abort transactions below suffix boundary
         if certify_tx.is_version_above_snapshot(Certifier::get_certifier_base_ver(suffix_head, certify_tx.vers)) {
+            debug!(
+                "Aborting due snapshot for candidate below suffix head. version = {} | suffix_head = {} | snapshot = {} ",
+                certify_tx.vers, suffix_head, certify_tx.snapshot,
+            );
             return CertifyOutcome::Aborted {
                 version: None,
                 discord: Discord::Permissive,
@@ -96,6 +101,10 @@ impl Certifier {
             }
             None
         }) {
+            debug!(
+                "Aborting due to version {} having antidependency against version = {} ",
+                certify_tx.vers, antidependecy_vers,
+            );
             return CertifyOutcome::Aborted {
                 version: Some(antidependecy_vers),
                 discord: Discord::Assertive,

--- a/packages/talos_certifier/src/core.rs
+++ b/packages/talos_certifier/src/core.rs
@@ -45,6 +45,7 @@ impl DecisionChannelMessage {
 pub enum ChannelMessage<T: CandidateMessageBaseTrait> {
     Candidate(Box<CandidateChannelMessage<T>>),
     Decision(Box<DecisionChannelMessage>),
+    Reset,
 }
 
 #[derive(Debug, Display, Eq, PartialEq, EnumString)]

--- a/packages/talos_certifier/src/services/message_receiver_service.rs
+++ b/packages/talos_certifier/src/services/message_receiver_service.rs
@@ -15,12 +15,26 @@ use crate::{
     ChannelMessage,
 };
 
+#[derive(Debug)]
+pub struct MessageReceiverServiceConfig {
+    /// Minimum offset lag to retain.
+    /// Higher the value, lesser the frequency of commit.
+    /// This would help in hydrating the suffix in certifier so as to help suffix retain a minimum size to
+    /// reduce the initial aborts for fresh certification requests.
+    pub min_commit_threshold: u64,
+    /// Frequency at which to commit should be issued in ms
+    pub commit_frequency_ms: u64,
+}
+
 pub struct MessageReceiverService {
     pub receiver: Box<dyn MessageReciever<Message = ChannelMessage<CandidateMessage>> + Send + Sync>,
     pub message_channel_tx: mpsc::Sender<ChannelMessage<CandidateMessage>>,
     pub commit_offset: Arc<AtomicI64>,
     pub system: System,
     pub commit_interval: Interval,
+    pub config: MessageReceiverServiceConfig,
+    /// The last offset that was committed.
+    pub last_committed_offset: i64,
 }
 
 impl MessageReceiverService {
@@ -29,19 +43,45 @@ impl MessageReceiverService {
         message_channel_tx: mpsc::Sender<ChannelMessage<CandidateMessage>>,
         commit_offset: Arc<AtomicI64>,
         system: System,
+        config: MessageReceiverServiceConfig,
     ) -> Self {
         Self {
             receiver,
             message_channel_tx,
             system,
             commit_offset,
-            commit_interval: tokio::time::interval(Duration::from_millis(10_000)),
+            commit_interval: tokio::time::interval(Duration::from_millis(config.commit_frequency_ms)),
+            config,
+            last_committed_offset: 0,
         }
     }
 
     pub async fn subscribe(&self) -> Result<(), SystemServiceError> {
         self.receiver.subscribe().await?;
         Ok(())
+    }
+
+    /// Get the offset to commit after checking against the minimum lag to maintain.
+    pub fn get_commit_offset(&self) -> Option<i64> {
+        let offset = self.commit_offset.load(std::sync::atomic::Ordering::Relaxed);
+        let offset_to_commit = offset - self.config.min_commit_threshold as i64;
+
+        // If we cannot maintain the minimum offset, we return None.
+        if offset_to_commit < 0 {
+            None
+        } else {
+            Some(offset_to_commit)
+        }
+    }
+
+    pub fn try_commit(&mut self) {
+        if let Some(offset) = self.get_commit_offset() {
+            if let Err(update_error) = self.receiver.update_offset_to_commit(offset) {
+                error!("Failed to update offset {offset} with error {update_error:?}");
+            } else if let Err(e) = self.receiver.commit() {
+                error!("Failed to commit offset {offset} with error {e:?}");
+            };
+        }
     }
 }
 
@@ -84,9 +124,7 @@ impl SystemService for MessageReceiverService {
           }
           //** commit message
           _ = self.commit_interval.tick() => {
-            let offset = self.commit_offset.load(std::sync::atomic::Ordering::Relaxed);
-            self.receiver.update_offset_to_commit(offset)?;
-            self.receiver.commit_async();
+            self.try_commit();
           }
         }
 

--- a/packages/talos_certifier/src/services/mod.rs
+++ b/packages/talos_certifier/src/services/mod.rs
@@ -6,7 +6,7 @@ mod message_receiver_service;
 pub use certifier_service::{CertifierService, CertifierServiceConfig};
 pub use decision_outbox_service::DecisionOutboxService;
 pub use healthcheck_service::HealthCheckService;
-pub use message_receiver_service::MessageReceiverService;
+pub use message_receiver_service::{MessageReceiverService, MessageReceiverServiceConfig};
 
 #[cfg(test)]
 pub mod tests;

--- a/packages/talos_certifier_adapters/Cargo.toml
+++ b/packages/talos_certifier_adapters/Cargo.toml
@@ -22,9 +22,11 @@ env_logger = { workspace = true }
 # Async
 tokio = { workspace = true }
 async-trait = { workspace = true }
-futures-util = "0.3.21"
+# Futures
+futures-util = "0.3.26"
+futures-executor = "0.3.28"
 # Kafka
-rdkafka = { version = "0.34.0", features = ["sasl"]  }
+rdkafka = { version = "0.34.0", features = ["sasl"] }
 
 #  Ahash hashmap
 ahash = "0.8.3"
@@ -48,10 +50,10 @@ thiserror = "1.0.31"
 mockall = "0.11.0"
 
 # internal crates
-talos_metrics =       { path = "../talos_metrics", version = "0.2.43-dev" }
-talos_certifier =     { path = "../talos_certifier", version = "0.2.43-dev" }
-talos_suffix =        { path = "../talos_suffix", version = "0.2.43-dev" }
-talos_common_utils =  { path = "../talos_common_utils", version = "0.2.43-dev" }
+talos_metrics = { path = "../talos_metrics", version = "0.2.43-dev" }
+talos_certifier = { path = "../talos_certifier", version = "0.2.43-dev" }
+talos_suffix = { path = "../talos_suffix", version = "0.2.43-dev" }
+talos_common_utils = { path = "../talos_common_utils", version = "0.2.43-dev" }
 talos_rdkafka_utils = { path = "../talos_rdkafka_utils", version = "0.2.43-dev" }
 
 

--- a/packages/talos_certifier_adapters/src/certifier_context.rs
+++ b/packages/talos_certifier_adapters/src/certifier_context.rs
@@ -1,0 +1,38 @@
+use futures_executor::block_on;
+use log::{error, info};
+use rdkafka::{
+    consumer::{ConsumerContext, Rebalance},
+    ClientContext,
+};
+use talos_certifier::{model::CandidateMessage, ChannelMessage};
+use tokio::sync::mpsc;
+
+/// Certifier's consumer context used to detect a rebalance and send a `ChannelMessage::Reset` to reset the suffix in `certifier service`.
+pub struct CertifierConsumerContext {
+    pub topic: String,
+    pub message_channel_tx: mpsc::Sender<ChannelMessage<CandidateMessage>>,
+}
+
+impl ClientContext for CertifierConsumerContext {}
+impl ConsumerContext for CertifierConsumerContext {
+    fn post_rebalance(&self, rebalance: &rdkafka::consumer::Rebalance<'_>) {
+        match rebalance {
+            Rebalance::Assign(partitions) => {
+                let k = partitions.elements_for_topic(&self.topic);
+                if !k.is_empty() {
+                    info!("Assigned to partition of certification topic: {:?}", self.topic);
+                }
+            }
+            Rebalance::Revoke(partitions) => {
+                let k = partitions.elements_for_topic(&self.topic);
+                if !k.is_empty() {
+                    info!("Sending reset message due to partition revoked on certification topic {}", self.topic);
+                    if let Err(_error) = block_on(self.message_channel_tx.send(ChannelMessage::Reset)) {
+                        error!("Failed to send reset message");
+                    };
+                }
+            }
+            Rebalance::Error(e) => error!("Rebalance error: {}", e),
+        }
+    }
+}

--- a/packages/talos_certifier_adapters/src/certifier_kafka_pg.rs
+++ b/packages/talos_certifier_adapters/src/certifier_kafka_pg.rs
@@ -1,3 +1,4 @@
+use crate::certifier_context::CertifierConsumerContext;
 use crate::mock_certifier_service::MockCertifierService;
 use crate::PgConfig;
 use crate::{self as Adapters, KafkaConsumer};
@@ -69,7 +70,13 @@ pub async fn certifier_with_kafka_pg(channel_buffer: TalosCertifierChannelBuffer
     /* START - Kafka consumer service  */
     let commit_offset: Arc<AtomicI64> = Arc::new(0.into());
 
-    let kafka_consumer: KafkaConsumer<CandidateMessage> = Adapters::KafkaConsumer::new(&config.kafka_config);
+    let kafka_consumer: KafkaConsumer<CandidateMessage, CertifierConsumerContext> = Adapters::KafkaConsumer::with_context(
+        &config.kafka_config,
+        CertifierConsumerContext {
+            topic: config.kafka_config.topic.clone(),
+            message_channel_tx: tx.clone(),
+        },
+    );
     // let kafka_consumer_service = KafkaConsumerService::new(kafka_consumer, tx, system.clone());
     let message_receiver_service = MessageReceiverService::new(
         Box::new(kafka_consumer),

--- a/packages/talos_certifier_adapters/src/kafka/consumer.rs
+++ b/packages/talos_certifier_adapters/src/kafka/consumer.rs
@@ -1,7 +1,7 @@
 use std::{marker::PhantomData, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
-use log::{debug, info};
+use log::debug;
 use rdkafka::{
     consumer::{Consumer, DefaultConsumerContext, StreamConsumer},
     Message, TopicPartitionList,
@@ -48,7 +48,7 @@ impl<C> KafkaConsumer<C> {
     }
 
     pub fn store_offsets(&mut self, partition: i32, offset: i64) -> Result<(), KafkaAdapterError> {
-        info!("Partition {partition} and Offset {offset}");
+        debug!("Partition {partition} and Offset {offset}");
 
         let offset_to_update = offset + 1;
 

--- a/packages/talos_certifier_adapters/src/kafka/consumer.rs
+++ b/packages/talos_certifier_adapters/src/kafka/consumer.rs
@@ -1,7 +1,7 @@
 use std::{marker::PhantomData, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
-use log::debug;
+use log::{debug, info};
 use rdkafka::{
     consumer::{Consumer, DefaultConsumerContext, StreamConsumer},
     Message, TopicPartitionList,
@@ -48,7 +48,7 @@ impl<C> KafkaConsumer<C> {
     }
 
     pub fn store_offsets(&mut self, partition: i32, offset: i64) -> Result<(), KafkaAdapterError> {
-        debug!("Partition {partition} and Offset {offset}");
+        info!("Partition {partition} and Offset {offset}");
 
         let offset_to_update = offset + 1;
 

--- a/packages/talos_certifier_adapters/src/lib.rs
+++ b/packages/talos_certifier_adapters/src/lib.rs
@@ -17,4 +17,7 @@ mod mock_datastore;
 // custom certifiers with adapters
 mod certifier_kafka_pg;
 
+// custom certifier context
+pub mod certifier_context;
+
 pub use certifier_kafka_pg::{certifier_with_kafka_pg, Configuration, TalosCertifierChannelBuffers};

--- a/packages/talos_certifier_adapters/src/mock_certifier_service.rs
+++ b/packages/talos_certifier_adapters/src/mock_certifier_service.rs
@@ -62,6 +62,9 @@ impl SystemService for MockCertifierService {
                     Some(ChannelMessage::Decision(_)) => {
                         // ignore decision
                     },
+                    Some(ChannelMessage::Reset) => {
+                        // ignore reset
+                    },
 
                     None => (),
                 }

--- a/packages/talos_cohort_replicator/src/services/replicator_service.rs
+++ b/packages/talos_cohort_replicator/src/services/replicator_service.rs
@@ -120,6 +120,9 @@ where
 
                         time_last_item_send_end_ns = OffsetDateTime::now_utc().unix_timestamp_nanos();
                     },
+                    ChannelMessage::Reset => {
+                        debug!("Channel reset message received.");
+                    }
                 }
             }
         }

--- a/packages/talos_messenger_core/src/services/inbound_service.rs
+++ b/packages/talos_messenger_core/src/services/inbound_service.rs
@@ -298,6 +298,9 @@ where
 
 
                     },
+                    Ok(Some(ChannelMessage::Reset)) => {
+                        debug!("Channel reset message received.");
+                    },
                     Ok(None) => {
                         debug!("No message to process..");
                     },

--- a/packages/talos_messenger_core/src/services/inbound_service.rs
+++ b/packages/talos_messenger_core/src/services/inbound_service.rs
@@ -29,7 +29,7 @@ pub struct MessengerInboundServiceConfig {
     /// Default value is 5_000. Updating this value can impact the latency/throughput due to the frequency at which the commits will be issued.
     commit_size: u32,
     /// Frequency at which to commit should be done in ms
-    commit_frequency: u32,
+    commit_frequency_ms: u32,
     /// The allowed on_commit actions
     allowed_actions: HashMap<String, Vec<String>>,
 }
@@ -39,7 +39,7 @@ impl MessengerInboundServiceConfig {
         Self {
             allowed_actions,
             commit_size: commit_size.unwrap_or(5_000),
-            commit_frequency: commit_frequency.unwrap_or(10 * 1_000),
+            commit_frequency_ms: commit_frequency.unwrap_or(10 * 1_000),
         }
     }
 }
@@ -72,7 +72,7 @@ where
         suffix: Suffix<MessengerCandidate>,
         config: MessengerInboundServiceConfig,
     ) -> Self {
-        let commit_interval = tokio::time::interval(Duration::from_millis(config.commit_frequency as u64));
+        let commit_interval = tokio::time::interval(Duration::from_millis(config.commit_frequency_ms as u64));
         Self {
             message_receiver,
             tx_actions_channel,

--- a/packages/talos_suffix/src/suffix.rs
+++ b/packages/talos_suffix/src/suffix.rs
@@ -58,6 +58,17 @@ where
         Suffix { meta, messages }
     }
 
+    /// Resets the suffix to initial state.
+    pub fn reset(&mut self) {
+        // Reset suffix meta.
+        self.meta.head = 0;
+        self.meta.last_insert_vers = 0;
+        self.meta.prune_index = None;
+
+        // Clear the suffix messages vecdequeue.
+        self.messages.clear();
+    }
+
     pub fn index_from_head(&self, version: u64) -> Option<usize> {
         let head = self.meta.head;
         if version < head {


### PR DESCRIPTION
This change covers the work needed to maintain a minimum offset from committing so that when the certifier restarts or when the suffix is reset, the suffix will be hydrated with sufficient candidates to avoid initial aborts