### PR TITLE
Report all agent errors via metrics

### DIFF
--- a/packages/cohort_sdk/src/model/internal.rs
+++ b/packages/cohort_sdk/src/model/internal.rs
@@ -1,9 +1,11 @@
 use std::time::Duration;
 
+use strum::Display;
 use talos_agent::agent::errors::AgentError;
 
 use super::CertificationResponse;
 
+#[derive(Clone)]
 pub(crate) enum CertificationAttemptOutcome {
     Cancelled { reason: String },
     Success { response: CertificationResponse },
@@ -11,4 +13,27 @@ pub(crate) enum CertificationAttemptOutcome {
     AgentError { error: AgentError },
     DataError { reason: String },
     SnapshotTimeout { waited: Duration, conflict: u64 },
+}
+
+#[derive(Display)]
+pub(crate) enum CertificationAttemptFailure {
+    Aborted,
+    AgentError,
+    Cancelled,
+    Conflict,
+    DataError,
+    NotApplicable,
+}
+
+impl From<CertificationAttemptOutcome> for CertificationAttemptFailure {
+    fn from(value: CertificationAttemptOutcome) -> Self {
+        match value {
+            CertificationAttemptOutcome::Aborted { response: _ } => CertificationAttemptFailure::Aborted,
+            CertificationAttemptOutcome::AgentError { error: _ } => CertificationAttemptFailure::AgentError,
+            CertificationAttemptOutcome::Cancelled { reason: _ } => CertificationAttemptFailure::Cancelled,
+            CertificationAttemptOutcome::DataError { reason: _ } => CertificationAttemptFailure::DataError,
+            CertificationAttemptOutcome::SnapshotTimeout { waited: _, conflict: _ } => CertificationAttemptFailure::Conflict,
+            CertificationAttemptOutcome::Success { response: _ } => CertificationAttemptFailure::NotApplicable,
+        }
+    }
 }

--- a/packages/talos_agent/src/agent/errors.rs
+++ b/packages/talos_agent/src/agent/errors.rs
@@ -5,14 +5,14 @@ use strum::Display;
 use thiserror::Error as ThisError;
 use tokio::sync::mpsc::error::SendError;
 
-#[derive(Debug, Display, PartialEq)]
+#[derive(Debug, Display, PartialEq, Clone)]
 pub enum AgentErrorKind {
     Certification { xid: String },
     CertificationTimeout { xid: String, elapsed_ms: u128 },
     Messaging,
 }
 
-#[derive(Debug, ThisError)]
+#[derive(Debug, ThisError, Clone)]
 #[error("Talos agent error: '{kind}'.\nReason: {reason}\nCause: {cause:?}")]
 pub struct AgentError {
     pub kind: AgentErrorKind,

--- a/packages/talos_common_utils/src/otel/metric_constants.rs
+++ b/packages/talos_common_utils/src/otel/metric_constants.rs
@@ -5,6 +5,7 @@ pub const METRIC_NAME_AGENT_OFFSET_LAG: &str = "agent_offset_lag";
 pub const METRIC_NAME_CERTIFICATION_OFFSET: &str = "certification_offset";
 pub const METRIC_KEY_CERT_MESSAGE_TYPE: &str = "message_type";
 pub const METRIC_KEY_IS_SUCCESS: &str = "is_success";
+pub const METRIC_KEY_REASON: &str = "reason";
 pub const METRIC_VALUE_CERT_MESSAGE_TYPE_CANDIDATE: &str = "Candidate";
 pub const METRIC_VALUE_CERT_MESSAGE_TYPE_DECISION: &str = "Decision";
 pub const METRIC_KEY_CERT_DECISION_TYPE: &str = "decision";


### PR DESCRIPTION
Added "catch all" metric for agent errors, with label "reason" to break it down into sub errors. 

<img width="701" alt="Screenshot 2025-05-08 at 17 35 01" src="https://github.com/user-attachments/assets/abe5e1b0-46b6-4ed9-8939-148af8bc633b" />
