### PR TITLE
feat: replicator capture events for candidate to statemap install and publish metrics

### DIFF
--- a/packages/talos_cohort_replicator/src/core.rs
+++ b/packages/talos_cohort_replicator/src/core.rs
@@ -35,8 +35,6 @@ pub enum StatemapInstallState {
 }
 #[derive(Debug, Clone)]
 pub struct StatemapInstallerHashmap {
-    // enqueued at
-    // pub timestamp: i128, // nanos
     pub statemaps: Vec<StatemapItem>,
     pub version: u64,
     pub safepoint: Option<u64>,

--- a/packages/talos_cohort_replicator/src/core.rs
+++ b/packages/talos_cohort_replicator/src/core.rs
@@ -176,9 +176,10 @@ where
             self.suffix.insert(version, message).unwrap();
             self.metrics.add_candidate();
             if let Some(suffix_item) = self.suffix.get_mut(version) {
-                suffix_item
-                    .item
-                    .record_event(ReplicatorCandidateEvent::ReplicatorCandidateReceived, OffsetDateTime::now_utc().unix_timestamp_nanos());
+                suffix_item.item.record_event(
+                    ReplicatorCandidateEvent::ReplicatorCandidateReceived,
+                    OffsetDateTime::now_utc().unix_timestamp_nanos(),
+                );
             }
         } else {
             warn!("Version 0 will not be inserted into suffix.")
@@ -197,9 +198,10 @@ where
         self.suffix.set_safepoint(version, decision_message.get_safepoint());
 
         if let Some(suffix_item) = self.suffix.get_mut(version) {
-            suffix_item
-                .item
-                .record_event(ReplicatorCandidateEvent::ReplicatorDecisionReceived, OffsetDateTime::now_utc().unix_timestamp_nanos());
+            suffix_item.item.record_event(
+                ReplicatorCandidateEvent::ReplicatorDecisionReceived,
+                OffsetDateTime::now_utc().unix_timestamp_nanos(),
+            );
         }
 
         // If this is a duplicate, we mark it as installed (assuming the original version always comes first and therefore that will be installed.)

--- a/packages/talos_cohort_replicator/src/core.rs
+++ b/packages/talos_cohort_replicator/src/core.rs
@@ -8,7 +8,7 @@ use time::OffsetDateTime;
 use tracing::{debug, warn};
 
 use crate::{
-    events::{EventTimingsMap, ReplicatorEvents},
+    events::{EventTimingsMap, ReplicatorCandidateEvent},
     models::ReplicatorCandidateMessage,
 };
 
@@ -178,7 +178,7 @@ where
             if let Some(suffix_item) = self.suffix.get_mut(version) {
                 suffix_item
                     .item
-                    .set_timing_for_event(ReplicatorEvents::CandidateReceived, OffsetDateTime::now_utc().unix_timestamp_nanos());
+                    .record_event(ReplicatorCandidateEvent::ReplicatorCandidateReceived, OffsetDateTime::now_utc().unix_timestamp_nanos());
             }
         } else {
             warn!("Version 0 will not be inserted into suffix.")
@@ -199,7 +199,7 @@ where
         if let Some(suffix_item) = self.suffix.get_mut(version) {
             suffix_item
                 .item
-                .set_timing_for_event(ReplicatorEvents::DecisionReceived, OffsetDateTime::now_utc().unix_timestamp_nanos());
+                .record_event(ReplicatorCandidateEvent::ReplicatorDecisionReceived, OffsetDateTime::now_utc().unix_timestamp_nanos());
         }
 
         // If this is a duplicate, we mark it as installed (assuming the original version always comes first and therefore that will be installed.)

--- a/packages/talos_cohort_replicator/src/events.rs
+++ b/packages/talos_cohort_replicator/src/events.rs
@@ -2,24 +2,40 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-pub type EventTimingsMap = HashMap<ReplicatorEvents, i128>;
+pub type EventTimingsMap = HashMap<ReplicatorCandidateEvent, i128>;
 
+/// Capture the various events from the time a candidate arrived in replicator to when it's statemaps where installed.
+/// The various events can be used to capture the time taken in the journey between various events.
+///
+/// eg: Can be used to collect metrics at various key journey events.
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, Hash)]
-pub enum ReplicatorEvents {
-    // Replicator Service Thread events
-    CandidateReceived,
-    DecisionReceived,
-    StatemapPicked,
-    // Statemap Queue Service Thread events
-    StatemapReceivedAtQueueService,
-    StatemapSendToInstallService,
-    // Install Service Thread events
-    StatmapReceivedAtInstallService,
-    StatemapInstalled,
+pub enum ReplicatorCandidateEvent {
+    // ** Events captured for candidate on the Replicator Service Thread.
+    /// When the candidate message was consumed in the replicator
+    ReplicatorCandidateReceived,
+    /// When the decision message was consumed in the replicator
+    ReplicatorDecisionReceived,
+    /// When the statemap is picked and ready to send to the queue service
+    ReplicatorStatemapPicked,
+
+    // ** Events captured for statemaps associated with the candidate on the Statemap Queue Service thread.
+    /// When the statemap is received in the queue service
+    QueueStatemapReceived,
+    /// When the statemap is sent from the queue service to installer service
+    QueueStatemapSent,
+
+    // ** Events captured for statemaps associated with the candidate on the Statemap Installer thread.
+    /// When statemap is received by installer.
+    InstallerStatemapReceived,
+    /// When statemap installation completed in the installer service.
+    InstallerStatemapInstalled,
 }
 
 pub trait EventTimingsTrait {
-    fn set_timing_for_event(&mut self, event: ReplicatorEvents, ts: i128);
-    fn get_timing_by_event(&self, event: ReplicatorEvents) -> Option<i128>;
-    fn get_event_timings(&self) -> EventTimingsMap;
+    /// Record the time in nanosecond precision for an event.
+    fn record_event(&mut self, event: ReplicatorCandidateEvent, ts_ns: i128);
+    /// Get the time for an event.
+    fn get_event_timestamp(&self, event: ReplicatorCandidateEvent) -> Option<i128>;
+    /// Get all the events with their time
+    fn get_all_timings(&self) -> EventTimingsMap;
 }

--- a/packages/talos_cohort_replicator/src/events.rs
+++ b/packages/talos_cohort_replicator/src/events.rs
@@ -4,6 +4,31 @@ use serde::{Deserialize, Serialize};
 
 pub type EventTimingsMap = HashMap<ReplicatorCandidateEvent, i128>;
 
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct StatemapEvents {
+    timings: EventTimingsMap,
+}
+
+impl StatemapEvents {
+    pub fn with_timings(event_timings: EventTimingsMap) -> Self {
+        Self { timings: event_timings }
+    }
+}
+
+impl ReplicatorCandidateEventTimingsTrait for StatemapEvents {
+    fn record_event_timestamp(&mut self, event: ReplicatorCandidateEvent, ts_ns: i128) {
+        self.timings.insert(event, ts_ns);
+    }
+
+    fn get_event_timestamp(&self, event: ReplicatorCandidateEvent) -> Option<i128> {
+        self.timings.get(&event).copied()
+    }
+
+    fn get_all_timings(&self) -> EventTimingsMap {
+        self.timings.clone()
+    }
+}
+
 /// Capture the various events from the time a candidate arrived in replicator to when it's statemaps where installed.
 /// The various events can be used to capture the time taken in the journey between various events.
 ///
@@ -33,7 +58,7 @@ pub enum ReplicatorCandidateEvent {
 
 pub trait ReplicatorCandidateEventTimingsTrait {
     /// Record the time in nanosecond precision for an event.
-    fn record_event(&mut self, event: ReplicatorCandidateEvent, ts_ns: i128);
+    fn record_event_timestamp(&mut self, event: ReplicatorCandidateEvent, ts_ns: i128);
     /// Get the time for an event.
     fn get_event_timestamp(&self, event: ReplicatorCandidateEvent) -> Option<i128>;
     /// Get all the events with their time

--- a/packages/talos_cohort_replicator/src/events.rs
+++ b/packages/talos_cohort_replicator/src/events.rs
@@ -52,8 +52,10 @@ pub enum ReplicatorCandidateEvent {
     // ** Events captured for statemaps associated with the candidate on the Statemap Installer thread.
     /// When statemap is received by installer.
     InstallerStatemapReceived,
+    /// When statemap installation is going to be called in the installer service.
+    InstallerStatemapInstallionBegin,
     /// When statemap installation completed in the installer service.
-    InstallerStatemapInstalled,
+    InstallerStatemapInstallionComplete,
 }
 
 pub trait ReplicatorCandidateEventTimingsTrait {
@@ -67,7 +69,7 @@ pub trait ReplicatorCandidateEventTimingsTrait {
 
 // Below are some of the global events which could be exposed in future.
 // Some help for diagnosis and some can be used for Otel metrics - Counters and Gauges.
-// We already collect and publish metrics for some of these, but they are from done from within the library.
+// We already collect and publish metrics for some of these, but they are done from within each thread.
 // We may want to expose it out to the consumer of the library to help build their own metrics or diagnosis of the library at a given time.
 //
 // - In Replicator Service

--- a/packages/talos_cohort_replicator/src/events.rs
+++ b/packages/talos_cohort_replicator/src/events.rs
@@ -31,7 +31,7 @@ pub enum ReplicatorCandidateEvent {
     InstallerStatemapInstalled,
 }
 
-pub trait EventTimingsTrait {
+pub trait ReplicatorCandidateEventTimingsTrait {
     /// Record the time in nanosecond precision for an event.
     fn record_event(&mut self, event: ReplicatorCandidateEvent, ts_ns: i128);
     /// Get the time for an event.
@@ -39,3 +39,41 @@ pub trait EventTimingsTrait {
     /// Get all the events with their time
     fn get_all_timings(&self) -> EventTimingsMap;
 }
+
+// Below are some of the global events which could be exposed in future.
+// Some help for diagnosis and some can be used for Otel metrics - Counters and Gauges.
+// We already collect and publish metrics for some of these, but they are from done from within the library.
+// We may want to expose it out to the consumer of the library to help build their own metrics or diagnosis of the library at a given time.
+//
+// - In Replicator Service
+//  - Suffix size
+//  - Suffix head
+//  - Last candidate version received
+//  - Last decision version received
+//  - Total candidates received
+//  - Total decision received
+//  - Last commit version
+//  - Last version whose statemap was sent for Queue service
+//
+// - In Queue Service
+//  - Last version whose statemap was received
+//  - Channel depth
+//  - Queue size
+//  - Queue head
+//  - Last version whose statemap was sent to installer
+//  - Last snapshot version while calling the update snapshot
+//  - Last snapshot tracked internally
+//
+// - In Installer Service
+//  - Last version whose statemap was received
+//  - Channel depth
+//  - No. of items currently being installed
+//
+// - Backpressure
+//  - Backpressure max applied
+//  - Backpressure total applied
+//  - Number of times backpressure was applied
+//
+// - Errors
+//  - Statemap Installation total Error count
+//  - Snapshot update total Error count

--- a/packages/talos_cohort_replicator/src/events.rs
+++ b/packages/talos_cohort_replicator/src/events.rs
@@ -1,0 +1,25 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+pub type EventTimingsMap = HashMap<ReplicatorEvents, i128>;
+
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, Hash)]
+pub enum ReplicatorEvents {
+    // Replicator Service Thread events
+    CandidateReceived,
+    DecisionReceived,
+    StatemapPicked,
+    // Statemap Queue Service Thread events
+    StatemapReceivedAtQueueService,
+    StatemapSendToInstallService,
+    // Install Service Thread events
+    StatmapReceivedAtInstallService,
+    StatemapInstalled,
+}
+
+pub trait EventTimingsTrait {
+    fn set_timing_for_event(&mut self, event: ReplicatorEvents, ts: i128);
+    fn get_timing_by_event(&self, event: ReplicatorEvents) -> Option<i128>;
+    fn get_event_timings(&self) -> EventTimingsMap;
+}

--- a/packages/talos_cohort_replicator/src/lib.rs
+++ b/packages/talos_cohort_replicator/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod callbacks;
 mod core;
 pub mod errors;
+pub mod events;
 mod models;
 pub mod otel;
 mod services;

--- a/packages/talos_cohort_replicator/src/models/replicator_candidate.rs
+++ b/packages/talos_cohort_replicator/src/models/replicator_candidate.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 
 use crate::{
     core::CandidateDecisionOutcome,
-    events::{EventTimingsMap, EventTimingsTrait, ReplicatorCandidateEvent},
+    events::{EventTimingsMap, ReplicatorCandidateEvent, ReplicatorCandidateEventTimingsTrait},
     suffix::ReplicatorSuffixItemTrait,
 };
 
@@ -60,7 +60,7 @@ impl ReplicatorSuffixItemTrait for ReplicatorCandidate {
     }
 }
 
-impl EventTimingsTrait for ReplicatorCandidate {
+impl ReplicatorCandidateEventTimingsTrait for ReplicatorCandidate {
     fn record_event(&mut self, event: ReplicatorCandidateEvent, ts_ns: i128) {
         self.event_timings.insert(event, ts_ns);
     }

--- a/packages/talos_cohort_replicator/src/models/replicator_candidate.rs
+++ b/packages/talos_cohort_replicator/src/models/replicator_candidate.rs
@@ -2,8 +2,13 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use time::OffsetDateTime;
 
-use crate::{core::CandidateDecisionOutcome, suffix::ReplicatorSuffixItemTrait};
+use crate::{
+    core::CandidateDecisionOutcome,
+    events::{EventTimingsMap, EventTimingsTrait, ReplicatorEvents},
+    suffix::ReplicatorSuffixItemTrait,
+};
 
 use super::candidate_message::ReplicatorCandidateMessage;
 
@@ -19,6 +24,9 @@ pub struct ReplicatorCandidate {
 
     #[serde(skip_deserializing)]
     pub is_installed: bool,
+
+    // pub event_timings: ReplicatorCandidateTimings,
+    pub event_timings: EventTimingsMap,
 }
 
 impl From<ReplicatorCandidateMessage> for ReplicatorCandidate {
@@ -28,6 +36,7 @@ impl From<ReplicatorCandidateMessage> for ReplicatorCandidate {
             safepoint: None,
             decision_outcome: None,
             is_installed: false,
+            event_timings: HashMap::new(),
         }
     }
 }
@@ -50,5 +59,17 @@ impl ReplicatorSuffixItemTrait for ReplicatorCandidate {
     }
     fn is_installed(&self) -> bool {
         self.is_installed
+    }
+}
+
+impl EventTimingsTrait for ReplicatorCandidate {
+    fn set_timing_for_event(&mut self, event: ReplicatorEvents, ts: i128) {
+        self.event_timings.insert(event, ts);
+    }
+    fn get_timing_by_event(&self, event: ReplicatorEvents) -> Option<i128> {
+        self.event_timings.get(&event).copied()
+    }
+    fn get_event_timings(&self) -> EventTimingsMap {
+        self.event_timings.clone()
     }
 }

--- a/packages/talos_cohort_replicator/src/models/replicator_candidate.rs
+++ b/packages/talos_cohort_replicator/src/models/replicator_candidate.rs
@@ -61,7 +61,7 @@ impl ReplicatorSuffixItemTrait for ReplicatorCandidate {
 }
 
 impl ReplicatorCandidateEventTimingsTrait for ReplicatorCandidate {
-    fn record_event(&mut self, event: ReplicatorCandidateEvent, ts_ns: i128) {
+    fn record_event_timestamp(&mut self, event: ReplicatorCandidateEvent, ts_ns: i128) {
         self.event_timings.insert(event, ts_ns);
     }
     fn get_event_timestamp(&self, event: ReplicatorCandidateEvent) -> Option<i128> {

--- a/packages/talos_cohort_replicator/src/models/replicator_candidate.rs
+++ b/packages/talos_cohort_replicator/src/models/replicator_candidate.rs
@@ -24,7 +24,6 @@ pub struct ReplicatorCandidate {
     #[serde(skip_deserializing)]
     pub is_installed: bool,
 
-    // pub event_timings: ReplicatorCandidateTimings,
     pub event_timings: EventTimingsMap,
 }
 

--- a/packages/talos_cohort_replicator/src/models/replicator_candidate.rs
+++ b/packages/talos_cohort_replicator/src/models/replicator_candidate.rs
@@ -2,11 +2,10 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use time::OffsetDateTime;
 
 use crate::{
     core::CandidateDecisionOutcome,
-    events::{EventTimingsMap, EventTimingsTrait, ReplicatorEvents},
+    events::{EventTimingsMap, EventTimingsTrait, ReplicatorCandidateEvent},
     suffix::ReplicatorSuffixItemTrait,
 };
 
@@ -63,13 +62,13 @@ impl ReplicatorSuffixItemTrait for ReplicatorCandidate {
 }
 
 impl EventTimingsTrait for ReplicatorCandidate {
-    fn set_timing_for_event(&mut self, event: ReplicatorEvents, ts: i128) {
-        self.event_timings.insert(event, ts);
+    fn record_event(&mut self, event: ReplicatorCandidateEvent, ts_ns: i128) {
+        self.event_timings.insert(event, ts_ns);
     }
-    fn get_timing_by_event(&self, event: ReplicatorEvents) -> Option<i128> {
+    fn get_event_timestamp(&self, event: ReplicatorCandidateEvent) -> Option<i128> {
         self.event_timings.get(&event).copied()
     }
-    fn get_event_timings(&self) -> EventTimingsMap {
+    fn get_all_timings(&self) -> EventTimingsMap {
         self.event_timings.clone()
     }
 }

--- a/packages/talos_cohort_replicator/src/models/statemap_installer_queue.rs
+++ b/packages/talos_cohort_replicator/src/models/statemap_installer_queue.rs
@@ -6,7 +6,7 @@ use tracing::{debug, info};
 
 use crate::{
     core::{StatemapInstallState, StatemapInstallerHashmap},
-    events::ReplicatorCandidateEvent,
+    events::{ReplicatorCandidateEvent, ReplicatorCandidateEventTimingsTrait},
     utils::installer_utils::{is_queue_item_above_version, is_queue_item_serializable, is_queue_item_state_match},
 };
 
@@ -48,7 +48,7 @@ impl StatemapInstallerQueue {
     pub fn update_queue_item_state(&mut self, version: &u64, state: StatemapInstallState) -> Option<i128> {
         let item = self.queue.get_mut(version)?;
         item.state = state;
-        item.event_timings.get(&ReplicatorCandidateEvent::QueueStatemapReceived).copied()
+        item.events.get_event_timestamp(ReplicatorCandidateEvent::QueueStatemapReceived)
     }
 
     pub fn prune_till_version(&mut self, version: u64) -> Option<u64> {
@@ -183,9 +183,8 @@ impl StatemapInstallerQueue {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
 
-    use crate::core::StatemapInstallerHashmap;
+    use crate::{core::StatemapInstallerHashmap, events::StatemapEvents};
 
     use super::StatemapInstallerQueue;
 
@@ -195,7 +194,7 @@ mod tests {
             version: *version,
             safepoint,
             state: crate::core::StatemapInstallState::Awaiting,
-            event_timings: HashMap::new(),
+            events: StatemapEvents::default(),
         }
     }
 
@@ -213,7 +212,7 @@ mod tests {
                 safepoint: None,
                 state: crate::core::StatemapInstallState::Awaiting,
                 statemaps: vec![],
-                event_timings: HashMap::new(),
+                events: StatemapEvents::default(),
             },
         );
         let version = 3;
@@ -224,7 +223,7 @@ mod tests {
                 safepoint: None,
                 state: crate::core::StatemapInstallState::Awaiting,
                 statemaps: vec![],
-                event_timings: HashMap::new(),
+                events: StatemapEvents::default(),
             },
         );
 

--- a/packages/talos_cohort_replicator/src/models/statemap_installer_queue.rs
+++ b/packages/talos_cohort_replicator/src/models/statemap_installer_queue.rs
@@ -242,33 +242,11 @@ mod tests {
         assert_eq!(count, Some(1));
 
         //  Update the state for the version 5 as installed
-        let upd_5 = installer_queue.update_queue_item_state(&5, crate::core::StatemapInstallState::Installed);
+        installer_queue.update_queue_item_state(&5, crate::core::StatemapInstallState::Installed);
         //  Update the state for the version 3 as installed
-        let upd_3 = installer_queue.update_queue_item_state(&3, crate::core::StatemapInstallState::Installed);
+        installer_queue.update_queue_item_state(&3, crate::core::StatemapInstallState::Installed);
 
-        assert!(upd_5.is_none());
-        // As the items are put not in order, 3 is not removed.
-        assert!(upd_3.is_some());
         assert_eq!(installer_queue.queue.len(), 1);
-        // assert_eq!(installer_queue.queue.get(&5).unwrap().1.state, crate::core::StatemapInstallState::Installed);
-
-        // let count = installer_queue.prune_till_version(installer_queue.snapshot_version);
-        // // Althought version 5 and 3 are installed and safe to remove, as the snapshot is at 5, it can remove only the
-        // // contigous installed items till the snapshot.
-        // assert_eq!(count, 0);
-
-        // installer_queue.update_snapshot(10);
-
-        // let count = installer_queue.prune_till_version(installer_queue.snapshot_version);
-        // // If the snapshot version is an incorrect version which is not on the queue, `None` is returned.
-        // assert_eq!(count, 0);
-
-        // installer_queue.update_snapshot(3);
-
-        // let count = installer_queue.prune_till_version(installer_queue.snapshot_version);
-        // // Although version 3 is also safe to remove, it is the snapshot version and will not be removed.
-        // assert_eq!(count, 1);
-        // assert_eq!(installer_queue.queue.len(), 1);
     }
 
     #[test]

--- a/packages/talos_cohort_replicator/src/models/statemap_installer_queue.rs
+++ b/packages/talos_cohort_replicator/src/models/statemap_installer_queue.rs
@@ -6,7 +6,7 @@ use tracing::{debug, info};
 
 use crate::{
     core::{StatemapInstallState, StatemapInstallerHashmap},
-    events::ReplicatorEvents,
+    events::ReplicatorCandidateEvent,
     utils::installer_utils::{is_queue_item_above_version, is_queue_item_serializable, is_queue_item_state_match},
 };
 
@@ -48,7 +48,7 @@ impl StatemapInstallerQueue {
     pub fn update_queue_item_state(&mut self, version: &u64, state: StatemapInstallState) -> Option<i128> {
         let item = self.queue.get_mut(version)?;
         item.state = state;
-        item.event_timings.get(&ReplicatorEvents::StatemapReceivedAtQueueService).copied()
+        item.event_timings.get(&ReplicatorCandidateEvent::QueueStatemapReceived).copied()
     }
 
     pub fn prune_till_version(&mut self, version: u64) -> Option<u64> {

--- a/packages/talos_cohort_replicator/src/services/replicator_service.rs
+++ b/packages/talos_cohort_replicator/src/services/replicator_service.rs
@@ -4,6 +4,7 @@ use std::{fmt::Debug, time::Duration};
 use crate::{
     core::{Replicator, ReplicatorChannel},
     errors::ReplicatorError,
+    events::StatemapEvents,
     models::{ReplicatorCandidate, ReplicatorCandidateMessage},
     suffix::ReplicatorSuffixTrait,
     StatemapQueueChannelMessage,
@@ -193,7 +194,7 @@ where
 
                             // Send statemaps batch to
                             for (ver, statemap_vec, event_timings) in statemaps_batch {
-                                self.statemaps_tx.send(StatemapQueueChannelMessage::Message((ver, statemap_vec, event_timings))).await.unwrap();
+                                self.statemaps_tx.send(StatemapQueueChannelMessage::Message((ver, statemap_vec, StatemapEvents::with_timings(event_timings)))).await.unwrap();
                             }
 
                         },

--- a/packages/talos_cohort_replicator/src/services/replicator_service.rs
+++ b/packages/talos_cohort_replicator/src/services/replicator_service.rs
@@ -192,8 +192,8 @@ where
                             self.metrics.record_statemap_tx_count((self.statemaps_tx.max_capacity() - self.statemaps_tx.capacity()) as u64);
 
                             // Send statemaps batch to
-                            for (ver, statemap_vec) in statemaps_batch {
-                                self.statemaps_tx.send(StatemapQueueChannelMessage::Message((ver, statemap_vec))).await.unwrap();
+                            for (ver, statemap_vec, event_timings) in statemaps_batch {
+                                self.statemaps_tx.send(StatemapQueueChannelMessage::Message((ver, statemap_vec, event_timings))).await.unwrap();
                             }
 
                         },

--- a/packages/talos_cohort_replicator/src/services/statemap_queue_service.rs
+++ b/packages/talos_cohort_replicator/src/services/statemap_queue_service.rs
@@ -15,7 +15,7 @@ use crate::{
     callbacks::ReplicatorSnapshotProvider,
     core::{ReplicatorChannel, StatemapInstallState, StatemapInstallationStatus, StatemapInstallerHashmap, StatemapItem, StatemapQueueChannelMessage},
     errors::{ReplicatorError, ReplicatorErrorKind},
-    events::{EventTimingsMap, ReplicatorEvents},
+    events::{EventTimingsMap, ReplicatorCandidateEvent},
     models::StatemapInstallerQueue,
 };
 
@@ -293,10 +293,7 @@ where
                 };
 
                 // Record event when the item was received in queue service
-                event_timings.insert(
-                    ReplicatorEvents::StatemapReceivedAtQueueService,
-                    OffsetDateTime::now_utc().unix_timestamp_nanos(),
-                );
+                event_timings.insert(ReplicatorCandidateEvent::QueueStatemapReceived, OffsetDateTime::now_utc().unix_timestamp_nanos());
 
                 self.statemap_queue.insert_queue_item(
                     &version,

--- a/packages/talos_cohort_replicator/src/services/statemap_queue_service.rs
+++ b/packages/talos_cohort_replicator/src/services/statemap_queue_service.rs
@@ -15,6 +15,7 @@ use crate::{
     callbacks::ReplicatorSnapshotProvider,
     core::{ReplicatorChannel, StatemapInstallState, StatemapInstallationStatus, StatemapInstallerHashmap, StatemapItem, StatemapQueueChannelMessage},
     errors::{ReplicatorError, ReplicatorErrorKind},
+    events::{EventTimingsMap, ReplicatorEvents},
     models::StatemapInstallerQueue,
 };
 
@@ -133,7 +134,7 @@ where
     S: ReplicatorSnapshotProvider + Send + Sync,
 {
     statemaps_rx: mpsc::Receiver<StatemapQueueChannelMessage>,
-    installation_tx: mpsc::Sender<(u64, Vec<StatemapItem>)>,
+    installation_tx: mpsc::Sender<(u64, Vec<StatemapItem>, EventTimingsMap)>,
     installation_feedback_rx: mpsc::Receiver<StatemapInstallationStatus>,
     replicator_feedback: mpsc::Sender<ReplicatorChannel>,
     pub statemap_queue: StatemapInstallerQueue,
@@ -151,7 +152,7 @@ where
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         statemaps_rx: mpsc::Receiver<StatemapQueueChannelMessage>,
-        installation_tx: mpsc::Sender<(u64, Vec<StatemapItem>)>,
+        installation_tx: mpsc::Sender<(u64, Vec<StatemapItem>, EventTimingsMap)>,
         installation_feedback_rx: mpsc::Receiver<StatemapInstallationStatus>,
         replicator_feedback_tx: mpsc::Sender<ReplicatorChannel>,
         snapshot_api: Arc<S>,
@@ -228,7 +229,7 @@ where
         for key in items_to_install {
             // Send for installation
             if let Some(item) = self.statemap_queue.queue.get(&key) {
-                match self.installation_tx.send((key, item.statemaps.clone())).await {
+                match self.installation_tx.send((key, item.statemaps.clone(), item.event_timings.clone())).await {
                     Ok(_) => {
                         self.metrics.inflight_inc();
                         self.statemap_queue.update_queue_item_state(&key, StatemapInstallState::Inflight);
@@ -274,7 +275,7 @@ where
         // Insert messages into the internal queue and set the status to `StatemapInstallState::Awaiting`
         // Pick statemaps eligible to be installed and send to `statemap_installer_service`, and set their state to `StatemapInstallState::Inflight`.
         match channel_message {
-            Some(StatemapQueueChannelMessage::Message((version, statemaps))) => {
+            Some(StatemapQueueChannelMessage::Message((version, statemaps, mut event_timings))) => {
                 // Inserts the statemaps to the map
 
                 // Get the safepoint.
@@ -291,14 +292,21 @@ where
                     StatemapInstallState::Awaiting
                 };
 
+                // Record event when the item was received in queue service
+                event_timings.insert(
+                    ReplicatorEvents::StatemapReceivedAtQueueService,
+                    OffsetDateTime::now_utc().unix_timestamp_nanos(),
+                );
+
                 self.statemap_queue.insert_queue_item(
                     &version,
                     StatemapInstallerHashmap {
-                        timestamp: OffsetDateTime::now_utc().unix_timestamp_nanos(),
+                        // timestamp: OffsetDateTime::now_utc().unix_timestamp_nanos(),
                         statemaps,
                         version,
                         safepoint,
                         state,
+                        event_timings,
                     },
                 );
             }

--- a/packages/talos_cohort_replicator/src/services/statemap_queue_service.rs
+++ b/packages/talos_cohort_replicator/src/services/statemap_queue_service.rs
@@ -293,7 +293,10 @@ where
                 };
 
                 // Record event when the item was received in queue service
-                event_timings.insert(ReplicatorCandidateEvent::QueueStatemapReceived, OffsetDateTime::now_utc().unix_timestamp_nanos());
+                event_timings.insert(
+                    ReplicatorCandidateEvent::QueueStatemapReceived,
+                    OffsetDateTime::now_utc().unix_timestamp_nanos(),
+                );
 
                 self.statemap_queue.insert_queue_item(
                     &version,

--- a/packages/talos_cohort_replicator/src/services/statemap_queue_service.rs
+++ b/packages/talos_cohort_replicator/src/services/statemap_queue_service.rs
@@ -301,7 +301,6 @@ where
                 self.statemap_queue.insert_queue_item(
                     &version,
                     StatemapInstallerHashmap {
-                        // timestamp: OffsetDateTime::now_utc().unix_timestamp_nanos(),
                         statemaps,
                         version,
                         safepoint,

--- a/packages/talos_cohort_replicator/src/suffix.rs
+++ b/packages/talos_cohort_replicator/src/suffix.rs
@@ -7,11 +7,11 @@ use talos_suffix::{
 };
 use tracing::{debug, warn};
 
-use crate::events::EventTimingsTrait;
+use crate::events::ReplicatorCandidateEventTimingsTrait;
 
 use super::core::CandidateDecisionOutcome;
 
-pub trait ReplicatorSuffixItemTrait: EventTimingsTrait {
+pub trait ReplicatorSuffixItemTrait: ReplicatorCandidateEventTimingsTrait {
     fn get_safepoint(&self) -> &Option<u64>;
     fn get_statemap(&self) -> &Option<Vec<HashMap<String, Value>>>;
     fn set_safepoint(&mut self, safepoint: Option<u64>);

--- a/packages/talos_cohort_replicator/src/suffix.rs
+++ b/packages/talos_cohort_replicator/src/suffix.rs
@@ -7,9 +7,11 @@ use talos_suffix::{
 };
 use tracing::{debug, warn};
 
+use crate::events::EventTimingsTrait;
+
 use super::core::CandidateDecisionOutcome;
 
-pub trait ReplicatorSuffixItemTrait {
+pub trait ReplicatorSuffixItemTrait: EventTimingsTrait {
     fn get_safepoint(&self) -> &Option<u64>;
     fn get_statemap(&self) -> &Option<Vec<HashMap<String, Value>>>;
     fn set_safepoint(&mut self, safepoint: Option<u64>);

--- a/packages/talos_cohort_replicator/src/talos_cohort_replicator.rs
+++ b/packages/talos_cohort_replicator/src/talos_cohort_replicator.rs
@@ -92,16 +92,20 @@ where
             reason: "Unable to initialise OTEL logs and traces for replicator".into(),
             cause: Some(format!("{:?}", e)),
         })?;
-
-        if config.otel_telemetry.enable_metrics {
-            init_otel_metrics(config.otel_telemetry.grpc_endpoint).map_err(|e| ReplicatorError {
-                kind: ReplicatorErrorKind::Internal,
-                reason: "Unable to initialise OTEL metrics for replicator".into(),
-                cause: Some(format!("{:?}", e)),
-            })?;
-        }
     } else {
-        tracing::warn!("OTEL will not be initialised for this replicator instance, it may still be used if another module initialises it.")
+        tracing::warn!("Otel traces will not be initialised from within the replicator.");
+        tracing::warn!("If traces are required, either initialise from the calling app, or enable the flag otel_telemetry.enable_metrics to enable from within the library")
+    }
+
+    if config.otel_telemetry.enable_metrics {
+        init_otel_metrics(config.otel_telemetry.grpc_endpoint).map_err(|e| ReplicatorError {
+            kind: ReplicatorErrorKind::Internal,
+            reason: "Unable to initialise OTEL metrics for replicator".into(),
+            cause: Some(format!("{:?}", e)),
+        })?;
+    } else {
+        tracing::warn!("Otel metrics will not be initialised from within the replicator.");
+        tracing::warn!("If metrics are required, either initialise from the calling app, or enable the flag otel_telemetry.enable_metrics to enable from within the library")
     }
 
     // ---------- Channels to communicate between threads. ----------

--- a/packages/talos_cohort_replicator/src/tests/mod.rs
+++ b/packages/talos_cohort_replicator/src/tests/mod.rs
@@ -1,4 +1,5 @@
 mod replicator_service;
+mod statemap_installer_service;
 mod statemap_queue_service;
 pub mod suffix;
 pub mod test_utils;

--- a/packages/talos_cohort_replicator/src/tests/statemap_installer_service.rs
+++ b/packages/talos_cohort_replicator/src/tests/statemap_installer_service.rs
@@ -1,0 +1,56 @@
+use std::sync::Arc;
+
+use axum::async_trait;
+use time::{Duration, OffsetDateTime};
+use tokio::sync::mpsc;
+
+use crate::{
+    callbacks::ReplicatorInstaller,
+    events::{ReplicatorCandidateEventTimingsTrait, StatemapEvents},
+    services::statemap_installer_service::statemap_install_future,
+    StatemapItem,
+};
+
+struct MockReplicatorInstaller;
+
+#[async_trait]
+impl ReplicatorInstaller for MockReplicatorInstaller {
+    async fn install(&self, _sm: Vec<StatemapItem>, _version: u64) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+// Test the install event is set in StatemapEvents
+#[tokio::test]
+async fn test_install_event_set() {
+    let (statemap_installation_tx, _statemap_installation_rx) = mpsc::channel(50);
+    let mut statemap_events = StatemapEvents::default();
+    statemap_install_future(Arc::new(MockReplicatorInstaller), statemap_installation_tx, vec![], &mut statemap_events, 10).await;
+    assert_eq!(statemap_events.get_all_timings().len(), 2); // Install begin and complete events added
+    assert!(statemap_events
+        .get_event_timestamp(crate::events::ReplicatorCandidateEvent::InstallerStatemapInstallionBegin)
+        .is_some())
+}
+// Test the events passed into the future is retained + install event is set in StatemapEvents
+#[tokio::test]
+async fn test_propogated_events_retained() {
+    let (statemap_installation_tx, _statemap_installation_rx) = mpsc::channel(50);
+    let mut statemap_events = StatemapEvents::default();
+    statemap_events.record_event_timestamp(
+        crate::events::ReplicatorCandidateEvent::QueueStatemapReceived,
+        (OffsetDateTime::now_utc() - Duration::milliseconds(20)).unix_timestamp_nanos(),
+    );
+    statemap_events.record_event_timestamp(
+        crate::events::ReplicatorCandidateEvent::QueueStatemapSent,
+        (OffsetDateTime::now_utc() - Duration::milliseconds(20)).unix_timestamp_nanos(),
+    );
+    statemap_events.record_event_timestamp(
+        crate::events::ReplicatorCandidateEvent::InstallerStatemapReceived,
+        (OffsetDateTime::now_utc() - Duration::milliseconds(10)).unix_timestamp_nanos(),
+    );
+    statemap_install_future(Arc::new(MockReplicatorInstaller), statemap_installation_tx, vec![], &mut statemap_events, 10).await;
+    assert_eq!(statemap_events.get_all_timings().len(), 5); // The three events sent + install events added
+    assert!(statemap_events
+        .get_event_timestamp(crate::events::ReplicatorCandidateEvent::InstallerStatemapInstallionComplete)
+        .is_some())
+}

--- a/packages/talos_cohort_replicator/src/tests/statemap_queue_service.rs
+++ b/packages/talos_cohort_replicator/src/tests/statemap_queue_service.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     sync::{atomic::AtomicU64, Arc},
     time::Duration,
 };
@@ -62,7 +62,7 @@ async fn test_queue_service_snapshot_version_above_safepoint_below_snapshot() {
 
     let statemap_item = StatemapItem::new("TestAction".to_string(), 10, json!({"version": 10}), Some(7));
     statemaps_tx
-        .send(StatemapQueueChannelMessage::Message((10, vec![statemap_item])))
+        .send(StatemapQueueChannelMessage::Message((10, vec![statemap_item], HashMap::new())))
         .await
         .unwrap();
 
@@ -104,7 +104,10 @@ async fn test_queue_service_version_and_safepoint_below_snapshot() {
     });
 
     let statemap_item = StatemapItem::new("TestAction".to_string(), 7, json!({"version": 7}), Some(5));
-    statemaps_tx.send(StatemapQueueChannelMessage::Message((7, vec![statemap_item]))).await.unwrap();
+    statemaps_tx
+        .send(StatemapQueueChannelMessage::Message((7, vec![statemap_item], HashMap::new())))
+        .await
+        .unwrap();
 
     tokio::time::sleep(Duration::from_millis(10)).await;
 
@@ -167,7 +170,7 @@ async fn test_queue_service_insert_install_feedbacks() {
         safepoint,
     );
     statemaps_tx
-        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item])))
+        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item], HashMap::new())))
         .await
         .unwrap();
 
@@ -182,7 +185,7 @@ async fn test_queue_service_insert_install_feedbacks() {
         safepoint,
     );
     statemaps_tx
-        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item])))
+        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item], HashMap::new())))
         .await
         .unwrap();
 
@@ -209,7 +212,7 @@ async fn test_queue_service_insert_install_feedbacks() {
         safepoint,
     );
     statemaps_tx
-        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item])))
+        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item], HashMap::new())))
         .await
         .unwrap();
 
@@ -225,7 +228,7 @@ async fn test_queue_service_insert_install_feedbacks() {
         safepoint,
     );
     statemaps_tx
-        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item])))
+        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item], HashMap::new())))
         .await
         .unwrap();
 
@@ -241,7 +244,7 @@ async fn test_queue_service_insert_install_feedbacks() {
         safepoint,
     );
     statemaps_tx
-        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item])))
+        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item], HashMap::new())))
         .await
         .unwrap();
 
@@ -257,7 +260,7 @@ async fn test_queue_service_insert_install_feedbacks() {
         safepoint,
     );
     statemaps_tx
-        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item])))
+        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item], HashMap::new())))
         .await
         .unwrap();
 
@@ -328,7 +331,7 @@ async fn test_queue_service_insert_install_feedbacks() {
         safepoint,
     );
     statemaps_tx
-        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item])))
+        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item], HashMap::new())))
         .await
         .unwrap();
     // Run the service to insert this into queue.
@@ -421,7 +424,7 @@ async fn test_queue_service_effects_of_resetting_snapshot() {
         safepoint,
     );
     statemaps_tx
-        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item])))
+        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item], HashMap::new())))
         .await
         .unwrap();
     // Run the service to insert this into queue.
@@ -438,7 +441,7 @@ async fn test_queue_service_effects_of_resetting_snapshot() {
         safepoint,
     );
     statemaps_tx
-        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item])))
+        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item], HashMap::new())))
         .await
         .unwrap();
     // Run the service to insert this into queue.
@@ -455,7 +458,7 @@ async fn test_queue_service_effects_of_resetting_snapshot() {
         safepoint,
     );
     statemaps_tx
-        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item])))
+        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item], HashMap::new())))
         .await
         .unwrap();
     // Run the service to insert this into queue.
@@ -488,7 +491,7 @@ async fn test_queue_service_effects_of_resetting_snapshot() {
         safepoint,
     );
     statemaps_tx
-        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item])))
+        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item], HashMap::new())))
         .await
         .unwrap();
     // Run the service to insert this into queue.
@@ -582,7 +585,7 @@ async fn test_snapshot_updated_via_callback() {
         safepoint,
     );
     statemaps_tx
-        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item])))
+        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item], HashMap::new())))
         .await
         .unwrap();
     // Run the service to insert this into queue.
@@ -600,7 +603,7 @@ async fn test_snapshot_updated_via_callback() {
         safepoint,
     );
     statemaps_tx
-        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item])))
+        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item], HashMap::new())))
         .await
         .unwrap();
     // Run the service to insert this into queue.
@@ -656,7 +659,7 @@ async fn test_snapshot_updated_via_callback() {
         safepoint,
     );
     statemaps_tx
-        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item])))
+        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item], HashMap::new())))
         .await
         .unwrap();
     // Run the service to insert this into queue.
@@ -672,7 +675,7 @@ async fn test_snapshot_updated_via_callback() {
         safepoint,
     );
     statemaps_tx
-        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item])))
+        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item], HashMap::new())))
         .await
         .unwrap();
     // Run the service to insert this into queue.
@@ -688,7 +691,7 @@ async fn test_snapshot_updated_via_callback() {
         safepoint,
     );
     statemaps_tx
-        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item])))
+        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item], HashMap::new())))
         .await
         .unwrap();
     // Run the service to insert this into queue.
@@ -704,7 +707,7 @@ async fn test_snapshot_updated_via_callback() {
         safepoint,
     );
     statemaps_tx
-        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item])))
+        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item], HashMap::new())))
         .await
         .unwrap();
     // Run the service to insert this into queue.
@@ -836,7 +839,7 @@ async fn test_queue_service_last_installed_snapshot_against_internal_snapshot() 
         safepoint,
     );
     statemaps_tx
-        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item])))
+        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item], HashMap::new())))
         .await
         .unwrap();
 
@@ -862,7 +865,7 @@ async fn test_queue_service_last_installed_snapshot_against_internal_snapshot() 
         safepoint,
     );
     statemaps_tx
-        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item])))
+        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item], HashMap::new())))
         .await
         .unwrap();
 
@@ -891,7 +894,7 @@ async fn test_queue_service_last_installed_snapshot_against_internal_snapshot() 
     );
 
     statemaps_tx
-        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item])))
+        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item], HashMap::new())))
         .await
         .unwrap();
 
@@ -924,7 +927,7 @@ async fn test_queue_service_last_installed_snapshot_against_internal_snapshot() 
     );
 
     statemaps_tx
-        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item])))
+        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item], HashMap::new())))
         .await
         .unwrap();
 

--- a/packages/talos_cohort_replicator/src/tests/statemap_queue_service.rs
+++ b/packages/talos_cohort_replicator/src/tests/statemap_queue_service.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashSet,
     sync::{atomic::AtomicU64, Arc},
     time::Duration,
 };
@@ -11,6 +11,7 @@ use tokio::sync::mpsc::{self, error::TryRecvError};
 use crate::{
     callbacks::ReplicatorSnapshotProvider,
     core::StatemapInstallState,
+    events::StatemapEvents,
     services::statemap_queue_service::{self, StatemapQueueServiceConfig},
     StatemapItem, StatemapQueueChannelMessage,
 };
@@ -62,7 +63,7 @@ async fn test_queue_service_snapshot_version_above_safepoint_below_snapshot() {
 
     let statemap_item = StatemapItem::new("TestAction".to_string(), 10, json!({"version": 10}), Some(7));
     statemaps_tx
-        .send(StatemapQueueChannelMessage::Message((10, vec![statemap_item], HashMap::new())))
+        .send(StatemapQueueChannelMessage::Message((10, vec![statemap_item], StatemapEvents::default())))
         .await
         .unwrap();
 
@@ -105,7 +106,7 @@ async fn test_queue_service_version_and_safepoint_below_snapshot() {
 
     let statemap_item = StatemapItem::new("TestAction".to_string(), 7, json!({"version": 7}), Some(5));
     statemaps_tx
-        .send(StatemapQueueChannelMessage::Message((7, vec![statemap_item], HashMap::new())))
+        .send(StatemapQueueChannelMessage::Message((7, vec![statemap_item], StatemapEvents::default())))
         .await
         .unwrap();
 
@@ -170,7 +171,11 @@ async fn test_queue_service_insert_install_feedbacks() {
         safepoint,
     );
     statemaps_tx
-        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item], HashMap::new())))
+        .send(StatemapQueueChannelMessage::Message((
+            install_vers,
+            vec![statemap_item],
+            StatemapEvents::default(),
+        )))
         .await
         .unwrap();
 
@@ -185,7 +190,11 @@ async fn test_queue_service_insert_install_feedbacks() {
         safepoint,
     );
     statemaps_tx
-        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item], HashMap::new())))
+        .send(StatemapQueueChannelMessage::Message((
+            install_vers,
+            vec![statemap_item],
+            StatemapEvents::default(),
+        )))
         .await
         .unwrap();
 
@@ -212,7 +221,11 @@ async fn test_queue_service_insert_install_feedbacks() {
         safepoint,
     );
     statemaps_tx
-        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item], HashMap::new())))
+        .send(StatemapQueueChannelMessage::Message((
+            install_vers,
+            vec![statemap_item],
+            StatemapEvents::default(),
+        )))
         .await
         .unwrap();
 
@@ -228,7 +241,11 @@ async fn test_queue_service_insert_install_feedbacks() {
         safepoint,
     );
     statemaps_tx
-        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item], HashMap::new())))
+        .send(StatemapQueueChannelMessage::Message((
+            install_vers,
+            vec![statemap_item],
+            StatemapEvents::default(),
+        )))
         .await
         .unwrap();
 
@@ -244,7 +261,11 @@ async fn test_queue_service_insert_install_feedbacks() {
         safepoint,
     );
     statemaps_tx
-        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item], HashMap::new())))
+        .send(StatemapQueueChannelMessage::Message((
+            install_vers,
+            vec![statemap_item],
+            StatemapEvents::default(),
+        )))
         .await
         .unwrap();
 
@@ -260,7 +281,11 @@ async fn test_queue_service_insert_install_feedbacks() {
         safepoint,
     );
     statemaps_tx
-        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item], HashMap::new())))
+        .send(StatemapQueueChannelMessage::Message((
+            install_vers,
+            vec![statemap_item],
+            StatemapEvents::default(),
+        )))
         .await
         .unwrap();
 
@@ -331,7 +356,11 @@ async fn test_queue_service_insert_install_feedbacks() {
         safepoint,
     );
     statemaps_tx
-        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item], HashMap::new())))
+        .send(StatemapQueueChannelMessage::Message((
+            install_vers,
+            vec![statemap_item],
+            StatemapEvents::default(),
+        )))
         .await
         .unwrap();
     // Run the service to insert this into queue.
@@ -424,7 +453,11 @@ async fn test_queue_service_effects_of_resetting_snapshot() {
         safepoint,
     );
     statemaps_tx
-        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item], HashMap::new())))
+        .send(StatemapQueueChannelMessage::Message((
+            install_vers,
+            vec![statemap_item],
+            StatemapEvents::default(),
+        )))
         .await
         .unwrap();
     // Run the service to insert this into queue.
@@ -441,7 +474,11 @@ async fn test_queue_service_effects_of_resetting_snapshot() {
         safepoint,
     );
     statemaps_tx
-        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item], HashMap::new())))
+        .send(StatemapQueueChannelMessage::Message((
+            install_vers,
+            vec![statemap_item],
+            StatemapEvents::default(),
+        )))
         .await
         .unwrap();
     // Run the service to insert this into queue.
@@ -458,7 +495,11 @@ async fn test_queue_service_effects_of_resetting_snapshot() {
         safepoint,
     );
     statemaps_tx
-        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item], HashMap::new())))
+        .send(StatemapQueueChannelMessage::Message((
+            install_vers,
+            vec![statemap_item],
+            StatemapEvents::default(),
+        )))
         .await
         .unwrap();
     // Run the service to insert this into queue.
@@ -491,7 +532,11 @@ async fn test_queue_service_effects_of_resetting_snapshot() {
         safepoint,
     );
     statemaps_tx
-        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item], HashMap::new())))
+        .send(StatemapQueueChannelMessage::Message((
+            install_vers,
+            vec![statemap_item],
+            StatemapEvents::default(),
+        )))
         .await
         .unwrap();
     // Run the service to insert this into queue.
@@ -585,7 +630,11 @@ async fn test_snapshot_updated_via_callback() {
         safepoint,
     );
     statemaps_tx
-        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item], HashMap::new())))
+        .send(StatemapQueueChannelMessage::Message((
+            install_vers,
+            vec![statemap_item],
+            StatemapEvents::default(),
+        )))
         .await
         .unwrap();
     // Run the service to insert this into queue.
@@ -603,7 +652,11 @@ async fn test_snapshot_updated_via_callback() {
         safepoint,
     );
     statemaps_tx
-        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item], HashMap::new())))
+        .send(StatemapQueueChannelMessage::Message((
+            install_vers,
+            vec![statemap_item],
+            StatemapEvents::default(),
+        )))
         .await
         .unwrap();
     // Run the service to insert this into queue.
@@ -659,7 +712,11 @@ async fn test_snapshot_updated_via_callback() {
         safepoint,
     );
     statemaps_tx
-        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item], HashMap::new())))
+        .send(StatemapQueueChannelMessage::Message((
+            install_vers,
+            vec![statemap_item],
+            StatemapEvents::default(),
+        )))
         .await
         .unwrap();
     // Run the service to insert this into queue.
@@ -675,7 +732,11 @@ async fn test_snapshot_updated_via_callback() {
         safepoint,
     );
     statemaps_tx
-        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item], HashMap::new())))
+        .send(StatemapQueueChannelMessage::Message((
+            install_vers,
+            vec![statemap_item],
+            StatemapEvents::default(),
+        )))
         .await
         .unwrap();
     // Run the service to insert this into queue.
@@ -691,7 +752,11 @@ async fn test_snapshot_updated_via_callback() {
         safepoint,
     );
     statemaps_tx
-        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item], HashMap::new())))
+        .send(StatemapQueueChannelMessage::Message((
+            install_vers,
+            vec![statemap_item],
+            StatemapEvents::default(),
+        )))
         .await
         .unwrap();
     // Run the service to insert this into queue.
@@ -707,7 +772,11 @@ async fn test_snapshot_updated_via_callback() {
         safepoint,
     );
     statemaps_tx
-        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item], HashMap::new())))
+        .send(StatemapQueueChannelMessage::Message((
+            install_vers,
+            vec![statemap_item],
+            StatemapEvents::default(),
+        )))
         .await
         .unwrap();
     // Run the service to insert this into queue.
@@ -839,7 +908,11 @@ async fn test_queue_service_last_installed_snapshot_against_internal_snapshot() 
         safepoint,
     );
     statemaps_tx
-        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item], HashMap::new())))
+        .send(StatemapQueueChannelMessage::Message((
+            install_vers,
+            vec![statemap_item],
+            StatemapEvents::default(),
+        )))
         .await
         .unwrap();
 
@@ -865,7 +938,11 @@ async fn test_queue_service_last_installed_snapshot_against_internal_snapshot() 
         safepoint,
     );
     statemaps_tx
-        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item], HashMap::new())))
+        .send(StatemapQueueChannelMessage::Message((
+            install_vers,
+            vec![statemap_item],
+            StatemapEvents::default(),
+        )))
         .await
         .unwrap();
 
@@ -894,7 +971,11 @@ async fn test_queue_service_last_installed_snapshot_against_internal_snapshot() 
     );
 
     statemaps_tx
-        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item], HashMap::new())))
+        .send(StatemapQueueChannelMessage::Message((
+            install_vers,
+            vec![statemap_item],
+            StatemapEvents::default(),
+        )))
         .await
         .unwrap();
 
@@ -927,7 +1008,11 @@ async fn test_queue_service_last_installed_snapshot_against_internal_snapshot() 
     );
 
     statemaps_tx
-        .send(StatemapQueueChannelMessage::Message((install_vers, vec![statemap_item], HashMap::new())))
+        .send(StatemapQueueChannelMessage::Message((
+            install_vers,
+            vec![statemap_item],
+            StatemapEvents::default(),
+        )))
         .await
         .unwrap();
 

--- a/packages/talos_cohort_replicator/src/tests/suffix.rs
+++ b/packages/talos_cohort_replicator/src/tests/suffix.rs
@@ -5,7 +5,7 @@ use talos_suffix::{core::SuffixMeta, Suffix, SuffixTrait};
 
 use crate::{
     core::CandidateDecisionOutcome,
-    events::{EventTimingsMap, EventTimingsTrait},
+    events::{EventTimingsMap, ReplicatorCandidateEventTimingsTrait},
     suffix::{ReplicatorSuffixItemTrait, ReplicatorSuffixTrait},
 };
 
@@ -43,7 +43,7 @@ impl ReplicatorSuffixItemTrait for TestReplicatorSuffixItem {
     }
 }
 
-impl EventTimingsTrait for TestReplicatorSuffixItem {
+impl ReplicatorCandidateEventTimingsTrait for TestReplicatorSuffixItem {
     fn record_event(&mut self, event: crate::events::ReplicatorCandidateEvent, ts_ns: i128) {
         self.event_timings.insert(event, ts_ns);
     }

--- a/packages/talos_cohort_replicator/src/tests/suffix.rs
+++ b/packages/talos_cohort_replicator/src/tests/suffix.rs
@@ -5,6 +5,7 @@ use talos_suffix::{core::SuffixMeta, Suffix, SuffixTrait};
 
 use crate::{
     core::CandidateDecisionOutcome,
+    events::{EventTimingsMap, EventTimingsTrait},
     suffix::{ReplicatorSuffixItemTrait, ReplicatorSuffixTrait},
 };
 
@@ -14,6 +15,7 @@ struct TestReplicatorSuffixItem {
     decision: Option<CandidateDecisionOutcome>,
     statemap: Option<Vec<std::collections::HashMap<String, serde_json::Value>>>,
     is_installed: bool,
+    event_timings: EventTimingsMap,
 }
 
 impl ReplicatorSuffixItemTrait for TestReplicatorSuffixItem {
@@ -38,6 +40,20 @@ impl ReplicatorSuffixItemTrait for TestReplicatorSuffixItem {
 
     fn is_installed(&self) -> bool {
         self.is_installed
+    }
+}
+
+impl EventTimingsTrait for TestReplicatorSuffixItem {
+    fn record_event(&mut self, event: crate::events::ReplicatorCandidateEvent, ts_ns: i128) {
+        self.event_timings.insert(event, ts_ns);
+    }
+
+    fn get_event_timestamp(&self, event: crate::events::ReplicatorCandidateEvent) -> Option<i128> {
+        self.event_timings.get(&event).copied()
+    }
+
+    fn get_all_timings(&self) -> EventTimingsMap {
+        self.event_timings.clone()
     }
 }
 

--- a/packages/talos_cohort_replicator/src/tests/suffix.rs
+++ b/packages/talos_cohort_replicator/src/tests/suffix.rs
@@ -44,7 +44,7 @@ impl ReplicatorSuffixItemTrait for TestReplicatorSuffixItem {
 }
 
 impl ReplicatorCandidateEventTimingsTrait for TestReplicatorSuffixItem {
-    fn record_event(&mut self, event: crate::events::ReplicatorCandidateEvent, ts_ns: i128) {
+    fn record_event_timestamp(&mut self, event: crate::events::ReplicatorCandidateEvent, ts_ns: i128) {
         self.event_timings.insert(event, ts_ns);
     }
 

--- a/packages/talos_cohort_replicator/src/tests/test_utils.rs
+++ b/packages/talos_cohort_replicator/src/tests/test_utils.rs
@@ -9,7 +9,7 @@ use talos_suffix::SuffixItem;
 
 use crate::{
     core::CandidateDecisionOutcome,
-    events::{EventTimingsMap, EventTimingsTrait},
+    events::{EventTimingsMap, ReplicatorCandidateEventTimingsTrait},
     suffix::ReplicatorSuffixItemTrait,
 };
 
@@ -113,7 +113,7 @@ impl ReplicatorSuffixItemTrait for BankStatemapTestCandidate {
     }
 }
 
-impl EventTimingsTrait for BankStatemapTestCandidate {
+impl ReplicatorCandidateEventTimingsTrait for BankStatemapTestCandidate {
     fn record_event(&mut self, event: crate::events::ReplicatorCandidateEvent, ts_ns: i128) {
         self.event_timings.insert(event, ts_ns);
     }

--- a/packages/talos_cohort_replicator/src/tests/test_utils.rs
+++ b/packages/talos_cohort_replicator/src/tests/test_utils.rs
@@ -7,7 +7,11 @@ use serde_json::{json, Value};
 use std::collections::HashMap;
 use talos_suffix::SuffixItem;
 
-use crate::{core::CandidateDecisionOutcome, suffix::ReplicatorSuffixItemTrait};
+use crate::{
+    core::CandidateDecisionOutcome,
+    events::{EventTimingsMap, EventTimingsTrait},
+    suffix::ReplicatorSuffixItemTrait,
+};
 
 fn generate_bank_transfer_statemap_value() -> Value {
     let accounts_vec = (0..10).collect::<Vec<u32>>();
@@ -54,6 +58,7 @@ pub(crate) struct BankStatemapTestCandidate {
     pub decision_outcome: Option<CandidateDecisionOutcome>,
     pub statemap: Option<Vec<HashMap<String, Value>>>,
     pub is_installed: bool,
+    pub event_timings: EventTimingsMap,
 }
 
 impl BankStatemapTestCandidate {
@@ -63,6 +68,7 @@ impl BankStatemapTestCandidate {
             decision_outcome: Default::default(),
             statemap: Default::default(),
             is_installed: false,
+            event_timings: HashMap::new(),
         };
 
         item.generate_bank_transfers_statemap(statemap_count)
@@ -104,6 +110,20 @@ impl ReplicatorSuffixItemTrait for BankStatemapTestCandidate {
 
     fn is_installed(&self) -> bool {
         self.is_installed
+    }
+}
+
+impl EventTimingsTrait for BankStatemapTestCandidate {
+    fn record_event(&mut self, event: crate::events::ReplicatorCandidateEvent, ts_ns: i128) {
+        self.event_timings.insert(event, ts_ns);
+    }
+
+    fn get_event_timestamp(&self, event: crate::events::ReplicatorCandidateEvent) -> Option<i128> {
+        self.event_timings.get(&event).copied()
+    }
+
+    fn get_all_timings(&self) -> EventTimingsMap {
+        self.event_timings.clone()
     }
 }
 

--- a/packages/talos_cohort_replicator/src/tests/test_utils.rs
+++ b/packages/talos_cohort_replicator/src/tests/test_utils.rs
@@ -114,7 +114,7 @@ impl ReplicatorSuffixItemTrait for BankStatemapTestCandidate {
 }
 
 impl ReplicatorCandidateEventTimingsTrait for BankStatemapTestCandidate {
-    fn record_event(&mut self, event: crate::events::ReplicatorCandidateEvent, ts_ns: i128) {
+    fn record_event_timestamp(&mut self, event: crate::events::ReplicatorCandidateEvent, ts_ns: i128) {
         self.event_timings.insert(event, ts_ns);
     }
 

--- a/packages/talos_cohort_replicator/src/utils/replicator_utils.rs
+++ b/packages/talos_cohort_replicator/src/utils/replicator_utils.rs
@@ -23,7 +23,10 @@ pub fn get_statemap_from_suffix_items<'a, T: ReplicatorSuffixItemTrait + 'a>(
     messages.into_iter().fold(vec![], |mut acc, m| {
         // Record the time when the statemap item is picked.
         let mut event_timings = m.item.get_all_timings();
-        event_timings.insert(ReplicatorCandidateEvent::ReplicatorStatemapPicked, OffsetDateTime::now_utc().unix_timestamp_nanos());
+        event_timings.insert(
+            ReplicatorCandidateEvent::ReplicatorStatemapPicked,
+            OffsetDateTime::now_utc().unix_timestamp_nanos(),
+        );
         //  aborts
         if m.item.get_safepoint().is_none() {
             acc.push((m.item_ver, vec![], event_timings));

--- a/packages/talos_cohort_replicator/src/utils/replicator_utils.rs
+++ b/packages/talos_cohort_replicator/src/utils/replicator_utils.rs
@@ -3,7 +3,7 @@ use time::OffsetDateTime;
 
 use crate::{
     core::StatemapItem,
-    events::{EventTimingsMap, ReplicatorEvents},
+    events::{EventTimingsMap, ReplicatorCandidateEvent},
     suffix::ReplicatorSuffixItemTrait,
 };
 
@@ -22,8 +22,8 @@ pub fn get_statemap_from_suffix_items<'a, T: ReplicatorSuffixItemTrait + 'a>(
 ) -> Vec<(u64, Vec<StatemapItem>, EventTimingsMap)> {
     messages.into_iter().fold(vec![], |mut acc, m| {
         // Record the time when the statemap item is picked.
-        let mut event_timings = m.item.get_event_timings();
-        event_timings.insert(ReplicatorEvents::StatemapPicked, OffsetDateTime::now_utc().unix_timestamp_nanos());
+        let mut event_timings = m.item.get_all_timings();
+        event_timings.insert(ReplicatorCandidateEvent::ReplicatorStatemapPicked, OffsetDateTime::now_utc().unix_timestamp_nanos());
         //  aborts
         if m.item.get_safepoint().is_none() {
             acc.push((m.item_ver, vec![], event_timings));

--- a/packages/talos_cohort_replicator/src/utils/replicator_utils.rs
+++ b/packages/talos_cohort_replicator/src/utils/replicator_utils.rs
@@ -1,6 +1,11 @@
 use talos_suffix::SuffixItem;
+use time::OffsetDateTime;
 
-use crate::{core::StatemapItem, suffix::ReplicatorSuffixItemTrait};
+use crate::{
+    core::StatemapItem,
+    events::{EventTimingsMap, ReplicatorEvents},
+    suffix::ReplicatorSuffixItemTrait,
+};
 
 /// Get all contiguous items decided irrespective of committed or aborted.
 pub fn get_filtered_batch<'a, T: ReplicatorSuffixItemTrait + 'a>(messages: impl Iterator<Item = &'a SuffixItem<T>>) -> impl Iterator<Item = &'a SuffixItem<T>> {
@@ -14,11 +19,14 @@ pub fn get_filtered_batch<'a, T: ReplicatorSuffixItemTrait + 'a>(messages: impl 
 // TODO: Instrument with span
 pub fn get_statemap_from_suffix_items<'a, T: ReplicatorSuffixItemTrait + 'a>(
     messages: impl Iterator<Item = &'a SuffixItem<T>>,
-) -> Vec<(u64, Vec<StatemapItem>)> {
+) -> Vec<(u64, Vec<StatemapItem>, EventTimingsMap)> {
     messages.into_iter().fold(vec![], |mut acc, m| {
+        // Record the time when the statemap item is picked.
+        let mut event_timings = m.item.get_event_timings();
+        event_timings.insert(ReplicatorEvents::StatemapPicked, OffsetDateTime::now_utc().unix_timestamp_nanos());
         //  aborts
         if m.item.get_safepoint().is_none() {
-            acc.push((m.item_ver, vec![]));
+            acc.push((m.item_ver, vec![], event_timings));
             return acc;
         }
 
@@ -29,7 +37,6 @@ pub fn get_statemap_from_suffix_items<'a, T: ReplicatorSuffixItemTrait + 'a>(
                 let state_maps_to_append = sm_items.iter().map(|sm| {
                     let key = sm.keys().next().unwrap().to_string();
                     let payload = sm.get(&key).unwrap().clone();
-
                     StatemapItem {
                         action: key,
                         payload,
@@ -37,13 +44,13 @@ pub fn get_statemap_from_suffix_items<'a, T: ReplicatorSuffixItemTrait + 'a>(
                         safepoint: *m.item.get_safepoint(),
                     }
                 });
-                acc.push((m.item_ver, state_maps_to_append.collect::<Vec<StatemapItem>>()));
+                acc.push((m.item_ver, state_maps_to_append.collect::<Vec<StatemapItem>>(), event_timings));
                 acc
             }
             // when there is no statemap
             None => {
                 // Empty statemap items are send for installs anyways to update the snapshot
-                acc.push((m.item_ver, vec![]));
+                acc.push((m.item_ver, vec![], event_timings));
                 acc
             }
         }


### PR DESCRIPTION
- Capture the various events in the journey from candidate and decision message to statemap install
- Capture metrics from the events for candidate message received to statemap install and decision message received to statemap install
- This lays the foundation for the capturing events for various points during the journey of candidate received and to when its corresponding statemaps were install. This could be exposed to consuming apps later to build their own metrics.